### PR TITLE
Adopt released Ota v1.6.25 governance

### DIFF
--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -14,28 +14,28 @@ jobs:
   verify-native-linux:
     uses: ./.github/workflows/ota-verify-native-linux.yml
     with:
-      ota_projection_identity: sha256:4483dd3e4d051145537fcf50005f87666a063f7b0d15c2a56bb24318ba91e6fe
+      ota_projection_identity: sha256:f84e2ea06ac5eaee2d5c2eb26995c4d4cb23f19d42030467abf9617d3ae8f5aa
       ota_target_os: linux
       ota_runner: ubuntu-latest
 
   verify-native-macos:
     uses: ./.github/workflows/ota-verify-native-macos.yml
     with:
-      ota_projection_identity: sha256:cc187bf7de2f5e1eb9184f5fff62f87cbae7624df902a6dd64aeabc0b710fda5
+      ota_projection_identity: sha256:283e11795584f0391bebe1f9b7aff68e17e70e9fd36c376ed00c013728ae4264
       ota_target_os: macos
       ota_runner: macos-latest
 
   verify-native-windows:
     uses: ./.github/workflows/ota-verify-native-windows.yml
     with:
-      ota_projection_identity: sha256:70a69e93fece567b9c14fb63c7130c4ba98e7e6cc0e290d4bdbe7c016f8e44b0
+      ota_projection_identity: sha256:e3fbeb038a40296aaba67a7c5bd987db66f0ea08bc2aed35a32012b430c7cb40
       ota_target_os: windows
       ota_runner: windows-latest
 
   verify-container-linux:
     uses: ./.github/workflows/ota-verify-container-linux.yml
     with:
-      ota_projection_identity: sha256:5c341edd074591c3bc6c46797f0842107e6a6f2e17632ad09a5fd130f4908da3
+      ota_projection_identity: sha256:40a3f00e0000a3a6c91fdf8368bcc3ecdcbff17f1abb38822aea9706395ac3b8
       ota_target_os: linux
       ota_runner: ubuntu-latest
 
@@ -53,10 +53,8 @@ jobs:
           source: contract
       # `dev` is intentionally outside agent admission. This is an explicit
       # human-owned proof lane, not a generated agent-execution projection.
-      - name: Prove bounded native runtime
-        run: ota proof runtime --workflow sqlite-dev --mode native --json
-      - name: Archive native runtime receipt
-        run: ota receipt --workflow sqlite-dev --mode native --archive --json
+      - name: Prove and archive bounded native runtime
+        run: ota proof runtime --workflow sqlite-dev --mode native --archive --json
 
   runtime-container:
     name: Ubuntu bounded container runtime proof
@@ -67,10 +65,8 @@ jobs:
         with:
           source: contract
       # The same explicit, non-agent proof boundary applies in container mode.
-      - name: Prove bounded container runtime
-        run: ota proof runtime --workflow sqlite-dev --mode container --json
-      - name: Archive container runtime receipt
-        run: ota receipt --workflow sqlite-dev --mode container --archive --json
+      - name: Prove and archive bounded container runtime
+        run: ota proof runtime --workflow sqlite-dev --mode container --archive --json
 
   contract-ci-drift:
     name: Contract-to-CI drift gate

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -11,118 +11,72 @@ permissions:
   contents: read
 
 jobs:
-  sqlite-verification:
-    name: ${{ matrix.os }} SQLite verification
+  verify-native-linux:
+    uses: ./.github/workflows/ota-verify-native-linux.yml
+    with:
+      ota_projection_identity: sha256:ee3835bb4c532fd11a8d8082ab1eb10d0a8ee0f3fb2841a6480979c725dc768a
+      ota_target_os: linux
+      ota_runner: ubuntu-latest
+
+  verify-native-macos:
+    uses: ./.github/workflows/ota-verify-native-macos.yml
+    with:
+      ota_projection_identity: sha256:a8277aa9c1cf6ce81e0b6466c61d12eea654ceda56b25bb2c4322d3e1e25c186
+      ota_target_os: macos
+      ota_runner: macos-latest
+
+  verify-native-windows:
+    uses: ./.github/workflows/ota-verify-native-windows.yml
+    with:
+      ota_projection_identity: sha256:aa52e2760d9d73724de802ec62bbe027864485e59a82fdf63732430ab1fb4383
+      ota_target_os: windows
+      ota_runner: windows-latest
+
+  verify-container-linux:
+    uses: ./.github/workflows/ota-verify-container-linux.yml
+    with:
+      ota_projection_identity: sha256:4028a3c0a90dac4a9145f995b3ac630a3a4a27630879d8d963c7c2e788b11e29
+      ota_target_os: linux
+      ota_runner: ubuntu-latest
+
+  runtime-native:
+    name: ${{ matrix.os }} bounded runtime proof
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Enable pinned pnpm
-        shell: bash
-        run: corepack enable
-
-      - uses: ota-run/setup@v1.0.8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      # `dev` is intentionally outside agent admission. This is an explicit
+      # human-owned proof lane, not a generated agent-execution projection.
+      - name: Prove bounded native runtime
+        run: ota proof runtime --workflow sqlite-dev --mode native --json
+      - name: Archive native runtime receipt
+        run: ota receipt --workflow sqlite-dev --mode native --archive --json
 
-      - name: Validate contract
-        run: ota validate .
-
-      - name: Diagnose readiness
-        run: ota doctor --json
-
-      - name: Discover safe execution surface
-        run: ota tasks --safe --use --json
-
-      - name: Preview agent verification task
-        run: ota run verify --agent --dry-run --json
-
-      - name: Preview agent verification workflow
-        run: ota up --workflow verify --agent --dry-run --json
-
-      - name: Prove native task and workflow refusal canaries
-        run: |
-          ota run --agent --expect-refusal --json selfhost:up > ota-task-refusal-canary.json
-          ota json validate --schema refusal-canary.json --input ota-task-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
-          ota up --agent --expect-refusal --workflow selfhost --json > ota-workflow-refusal-canary.json
-          ota json validate --schema refusal-canary.json --input ota-workflow-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
-
-      - name: Run agent verification workflow
-        run: ota up --workflow verify --agent --json
-
-      - name: Archive verification receipt
-        run: ota receipt --workflow verify --archive --json
-
-      - name: Prove isolated native runtime
-        run: ota proof runtime --workflow sqlite-dev --json
-
-      - name: Archive runtime receipt
-        run: ota receipt --workflow sqlite-dev --archive --json
-
-  container-verification:
-    name: Ubuntu container verification
+  runtime-container:
+    name: Ubuntu bounded container runtime proof
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: ota-run/setup@v1.0.8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
-
-      - name: Validate container contract surface
-        run: ota validate .
-
-      - name: Diagnose container readiness
-        run: ota doctor --container --json
-
-      - name: Discover safe execution surface
-        run: ota tasks --safe --use --json
-
-      - name: Preview self-hosted Compose workflow
-        run: ota up --workflow selfhost --dry-run --json
-
-      - name: Preview agent container verification workflow
-        run: ota up --workflow verify --container --agent --dry-run --json
-
-      - name: Prove container task and workflow refusal canaries
-        run: |
-          ota run --agent --expect-refusal --container --json selfhost:up > ota-container-task-refusal-canary.json
-          ota json validate --schema refusal-canary.json --input ota-container-task-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
-          ota up --agent --expect-refusal --container --workflow selfhost --json > ota-container-workflow-refusal-canary.json
-          ota json validate --schema refusal-canary.json --input ota-container-workflow-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
-
-      - name: Run agent container verification workflow
-        run: ota up --workflow verify --container --agent --json
-
-      - name: Archive container verification receipt
-        run: ota receipt --workflow verify --archive --json
-
-      - name: Prove isolated container runtime
-        run: ota proof runtime --workflow sqlite-dev --container --json
-
+      # The same explicit, non-agent proof boundary applies in container mode.
+      - name: Prove bounded container runtime
+        run: ota proof runtime --workflow sqlite-dev --mode container --json
       - name: Archive container runtime receipt
-        run: ota receipt --workflow sqlite-dev --archive --json
+        run: ota receipt --workflow sqlite-dev --mode container --archive --json
 
   contract-ci-drift:
     name: Contract-to-CI drift gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Enable pinned pnpm
-        run: corepack enable
 
       - name: Fail on contract-to-CI workflow drift
         uses: ota-run/action@4fba25c6c0063af009d38e215d97ab1a925277c8

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -110,15 +110,12 @@ jobs:
       - name: Enable pinned pnpm
         run: corepack enable
 
-      - uses: ota-run/setup@v1.0.8
-        with:
-          source: contract
-
       - name: Fail on contract-to-CI workflow drift
         uses: ota-run/action@1.6.25-implementation
         with:
           command: doctor
-          install: never
+          source: contract
+          contract-path: ota.yaml
           fail-on-ci-drift: true
           comment-pr: false
           artifact-name: ota-contract-ci-drift

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -126,6 +126,13 @@ jobs:
       # human-owned proof lane, not a generated agent-execution projection.
       - name: Prove and archive bounded native runtime
         run: ota proof runtime --workflow sqlite-dev --mode native --archive --json
+      - name: Upload bounded native runtime proof
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ota-runtime-native-${{ matrix.os }}
+          path: .ota/proof
+          if-no-files-found: warn
 
   runtime-container:
     name: Ubuntu bounded container runtime proof
@@ -138,6 +145,13 @@ jobs:
       # The same explicit, non-agent proof boundary applies in container mode.
       - name: Prove and archive bounded container runtime
         run: ota proof runtime --workflow sqlite-dev --mode container --archive --json
+      - name: Upload bounded container runtime proof
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ota-runtime-container-linux
+          path: .ota/proof
+          if-no-files-found: warn
 
   contract-ci-drift:
     name: Contract-to-CI drift gate

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Discover safe execution surface
         run: ota tasks --safe --use --json
 
+      - name: Preview self-hosted Compose workflow
+        run: ota up --workflow selfhost --dry-run --json
+
       - name: Preview agent container verification workflow
         run: ota up --workflow verify --container --agent --dry-run --json
 
@@ -93,3 +96,29 @@ jobs:
 
       - name: Archive container runtime receipt
         run: ota receipt --workflow sqlite-dev --archive --json
+
+  contract-ci-drift:
+    name: Contract-to-CI drift gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable pinned pnpm
+        run: corepack enable
+
+      - uses: ota-run/setup@v1.0.8
+        with:
+          source: contract
+
+      - name: Fail on contract-to-CI workflow drift
+        uses: ota-run/action@1.6.25-implementation
+        with:
+          command: doctor
+          install: never
+          fail-on-ci-drift: true
+          comment-pr: false
+          artifact-name: ota-contract-ci-drift

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -3,7 +3,7 @@ name: Ota governance
 on:
   push:
     branches:
-      - bobai/kylrix-ota-pressure
+      - bobai/kylrix-ota-v1.6.25
   pull_request:
   workflow_dispatch:
 
@@ -14,28 +14,28 @@ jobs:
   verify-native-linux:
     uses: ./.github/workflows/ota-verify-native-linux.yml
     with:
-      ota_projection_identity: sha256:762e2558c7e97efd8603451e1c69709b9d54523744f50af592a1a94eb56b1a87
+      ota_projection_identity: sha256:90a79930b370ff46b5db7035e0087d45938c78a80c0cde7fad8e35325e2f1784
       ota_target_os: linux
       ota_runner: ubuntu-latest
 
   verify-native-macos:
     uses: ./.github/workflows/ota-verify-native-macos.yml
     with:
-      ota_projection_identity: sha256:0db3ef741dbc7a53feea9c457b0b89e27c3caa3d634ae2d5e504cacd959081e0
+      ota_projection_identity: sha256:b154aa6d4330908e29470ec4e79ee8222efe796d7cbea290b19f6e22ac4f3944
       ota_target_os: macos
       ota_runner: macos-latest
 
   verify-native-windows:
     uses: ./.github/workflows/ota-verify-native-windows.yml
     with:
-      ota_projection_identity: sha256:365fa1b76ef98cd81c2a8586916188d5c0bf47659a889cb6f576cea3b203acf4
+      ota_projection_identity: sha256:b3f5da2f77c0148800fda5410ef84c23924ac22385ed82ba34537cb80a86f8c5
       ota_target_os: windows
       ota_runner: windows-latest
 
   verify-container-linux:
     uses: ./.github/workflows/ota-verify-container-linux.yml
     with:
-      ota_projection_identity: sha256:8b4df2b46b55d84d46151a25309cc1df8aab6bfce1304a0a69f613cb7e7bc066
+      ota_projection_identity: sha256:41ab99843ceb929d2724859edaf3235f8913bc5455ee0fa37acebd03736bdbef
       ota_target_os: linux
       ota_runner: ubuntu-latest
 
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+      - uses: ota-run/setup@85bf49c11a5aa3ddedfa56c47682cfd40b238f1f # v1.0.9
         with:
           source: contract
 
@@ -119,7 +119,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+      - uses: ota-run/setup@85bf49c11a5aa3ddedfa56c47682cfd40b238f1f # v1.0.9
         with:
           source: contract
       # `dev` is intentionally outside agent admission. This is an explicit
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+      - uses: ota-run/setup@85bf49c11a5aa3ddedfa56c47682cfd40b238f1f # v1.0.9
         with:
           source: contract
       # The same explicit, non-agent proof boundary applies in container mode.

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -3,7 +3,7 @@ name: Ota governance
 on:
   push:
     branches:
-      - bobai/kylrix-ota-v1.6.25
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -14,30 +14,101 @@ jobs:
   verify-native-linux:
     uses: ./.github/workflows/ota-verify-native-linux.yml
     with:
-      ota_projection_identity: sha256:f84e2ea06ac5eaee2d5c2eb26995c4d4cb23f19d42030467abf9617d3ae8f5aa
+      ota_projection_identity: sha256:762e2558c7e97efd8603451e1c69709b9d54523744f50af592a1a94eb56b1a87
       ota_target_os: linux
       ota_runner: ubuntu-latest
 
   verify-native-macos:
     uses: ./.github/workflows/ota-verify-native-macos.yml
     with:
-      ota_projection_identity: sha256:283e11795584f0391bebe1f9b7aff68e17e70e9fd36c376ed00c013728ae4264
+      ota_projection_identity: sha256:0db3ef741dbc7a53feea9c457b0b89e27c3caa3d634ae2d5e504cacd959081e0
       ota_target_os: macos
       ota_runner: macos-latest
 
   verify-native-windows:
     uses: ./.github/workflows/ota-verify-native-windows.yml
     with:
-      ota_projection_identity: sha256:e3fbeb038a40296aaba67a7c5bd987db66f0ea08bc2aed35a32012b430c7cb40
+      ota_projection_identity: sha256:365fa1b76ef98cd81c2a8586916188d5c0bf47659a889cb6f576cea3b203acf4
       ota_target_os: windows
       ota_runner: windows-latest
 
   verify-container-linux:
     uses: ./.github/workflows/ota-verify-container-linux.yml
     with:
-      ota_projection_identity: sha256:40a3f00e0000a3a6c91fdf8368bcc3ecdcbff17f1abb38822aea9706395ac3b8
+      ota_projection_identity: sha256:8b4df2b46b55d84d46151a25309cc1df8aab6bfce1304a0a69f613cb7e7bc066
       ota_target_os: linux
       ota_runner: ubuntu-latest
+
+  strict-replay-policy-refusal:
+    name: Strict replay-input policy refusal
+    runs-on: ubuntu-latest
+    env:
+      OTA_POLICY: .ota/pressure-replay-policy.yaml
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+
+      - name: Prove strict refusal before setup or execution
+        shell: bash
+        run: |
+          test ! -e node_modules
+          test ! -e .env
+          test ! -e .next
+
+          set +e
+          ota doctor --workflow verify --json . > "$RUNNER_TEMP/ota-policy-doctor.json"
+          doctor_status=$?
+          ota up --workflow verify --mode native --agent --dry-run --json . > "$RUNNER_TEMP/ota-policy-preview.json"
+          preview_status=$?
+          ota up --workflow verify --mode native --agent --json --receipt . > "$RUNNER_TEMP/ota-policy-refusal.json"
+          refusal_status=$?
+          ota doctor --workflow verify --fix --json . > "$RUNNER_TEMP/ota-policy-doctor-fix.json"
+          doctor_fix_status=$?
+          set -e
+
+          test "$doctor_status" -ne 0
+          test "$preview_status" -ne 0
+          test "$refusal_status" -ne 0
+          test "$doctor_fix_status" -ne 0
+
+          jq -e '
+            .replay_input_policy.decision == "deny"
+            and .replay_input_policy.coverage == "insufficient"
+            and (.replay_input_policy.inputs | any(
+              .task == "verify"
+              and .id == "pnpm_lockfile"
+              and .status == "unpinned"
+            ))
+          ' "$RUNNER_TEMP/ota-policy-doctor.json"
+          jq -e '
+            .receipt.status == "blocked"
+            and .receipt.failure_origin == "replay_input_policy_deny"
+            and .receipt.replay_input_policy.decision == "deny"
+          ' "$RUNNER_TEMP/ota-policy-preview.json"
+          jq -e '
+            .receipt.status == "blocked"
+            and .receipt.failure_origin == "replay_input_policy_deny"
+            and .receipt.replay_input_policy.decision == "deny"
+          ' "$RUNNER_TEMP/ota-policy-refusal.json"
+          jq -e '
+            .replay_input_policy.decision == "deny"
+          ' "$RUNNER_TEMP/ota-policy-doctor-fix.json"
+
+          test ! -e node_modules
+          test ! -e .env
+          test ! -e .next
+          git diff --exit-code
+
+      - name: Upload strict replay-input refusal evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ota-strict-replay-input-refusal
+          path: ${{ runner.temp }}/ota-policy-*.json
+          if-no-files-found: error
 
   runtime-native:
     name: ${{ matrix.os }} bounded runtime proof

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -157,7 +157,7 @@ jobs:
     name: Contract-to-CI drift gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Fail on contract-to-CI workflow drift
         uses: ota-run/action@4fba25c6c0063af009d38e215d97ab1a925277c8

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -80,6 +80,7 @@ jobs:
           command: doctor
           source: contract
           contract-path: ota.yaml
+          workflow: verify
           fail-on-ci-drift: true
           comment-pr: false
           artifact-name: ota-contract-ci-drift

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -14,28 +14,28 @@ jobs:
   verify-native-linux:
     uses: ./.github/workflows/ota-verify-native-linux.yml
     with:
-      ota_projection_identity: sha256:ee3835bb4c532fd11a8d8082ab1eb10d0a8ee0f3fb2841a6480979c725dc768a
+      ota_projection_identity: sha256:4483dd3e4d051145537fcf50005f87666a063f7b0d15c2a56bb24318ba91e6fe
       ota_target_os: linux
       ota_runner: ubuntu-latest
 
   verify-native-macos:
     uses: ./.github/workflows/ota-verify-native-macos.yml
     with:
-      ota_projection_identity: sha256:a8277aa9c1cf6ce81e0b6466c61d12eea654ceda56b25bb2c4322d3e1e25c186
+      ota_projection_identity: sha256:cc187bf7de2f5e1eb9184f5fff62f87cbae7624df902a6dd64aeabc0b710fda5
       ota_target_os: macos
       ota_runner: macos-latest
 
   verify-native-windows:
     uses: ./.github/workflows/ota-verify-native-windows.yml
     with:
-      ota_projection_identity: sha256:aa52e2760d9d73724de802ec62bbe027864485e59a82fdf63732430ab1fb4383
+      ota_projection_identity: sha256:70a69e93fece567b9c14fb63c7130c4ba98e7e6cc0e290d4bdbe7c016f8e44b0
       ota_target_os: windows
       ota_runner: windows-latest
 
   verify-container-linux:
     uses: ./.github/workflows/ota-verify-container-linux.yml
     with:
-      ota_projection_identity: sha256:4028a3c0a90dac4a9145f995b3ac630a3a4a27630879d8d963c7c2e788b11e29
+      ota_projection_identity: sha256:5c341edd074591c3bc6c46797f0842107e6a6f2e17632ad09a5fd130f4908da3
       ota_target_os: linux
       ota_runner: ubuntu-latest
 

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Preview agent verification workflow
         run: ota up --workflow verify --agent --dry-run --json
 
+      - name: Prove native task and workflow refusal canaries
+        run: |
+          ota run --agent --expect-refusal --json selfhost:up > ota-task-refusal-canary.json
+          ota json validate --schema refusal-canary.json --input ota-task-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
+          ota up --agent --expect-refusal --workflow selfhost --json > ota-workflow-refusal-canary.json
+          ota json validate --schema refusal-canary.json --input ota-workflow-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
+
       - name: Run agent verification workflow
         run: ota up --workflow verify --agent --json
 
@@ -84,6 +91,13 @@ jobs:
 
       - name: Preview agent container verification workflow
         run: ota up --workflow verify --container --agent --dry-run --json
+
+      - name: Prove container task and workflow refusal canaries
+        run: |
+          ota run --agent --expect-refusal --container --json selfhost:up > ota-container-task-refusal-canary.json
+          ota json validate --schema refusal-canary.json --input ota-container-task-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
+          ota up --agent --expect-refusal --container --workflow selfhost --json > ota-container-workflow-refusal-canary.json
+          ota json validate --schema refusal-canary.json --input ota-container-workflow-refusal-canary.json --assert-eq ok=true --assert-eq status=refused_as_expected --assert-eq canary.execution_started=false --assert-eq canary.refusal.reason_family=requested_task_not_safe --assert-eq receipt.ok=false
 
       - name: Run agent container verification workflow
         run: ota up --workflow verify --container --agent --json

--- a/.github/workflows/ota-governance.yml
+++ b/.github/workflows/ota-governance.yml
@@ -111,7 +111,7 @@ jobs:
         run: corepack enable
 
       - name: Fail on contract-to-CI workflow drift
-        uses: ota-run/action@1.6.25-implementation
+        uses: ota-run/action@4fba25c6c0063af009d38e215d97ab1a925277c8
         with:
           command: doctor
           source: contract

--- a/.github/workflows/ota-verify-container-linux.yml
+++ b/.github/workflows/ota-verify-container-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:8b4df2b46b55d84d46151a25309cc1df8aab6bfce1304a0a69f613cb7e7bc066
+# ota:managed-github-projection v1 identity=sha256:41ab99843ceb929d2724859edaf3235f8913bc5455ee0fa37acebd03736bdbef
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-container-linux.yml
+++ b/.github/workflows/ota-verify-container-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:4028a3c0a90dac4a9145f995b3ac630a3a4a27630879d8d963c7c2e788b11e29
+# ota:managed-github-projection v1 identity=sha256:5c341edd074591c3bc6c46797f0842107e6a6f2e17632ad09a5fd130f4908da3
 name: Ota governance ('verify')
 
 on:
@@ -37,9 +37,9 @@ jobs:
         run: ota tasks --safe --use --json
       - name: Preview contract lane
         run: ota up --workflow 'verify' --mode container --agent --dry-run --json
-      - name: Run contract lane
-        run: ota up --workflow 'verify' --mode container --agent --json
-      - name: Archive contract receipt
+      - name: Execute finite contract task
+        run: ota run 'verify' --mode container --agent
+      - name: Archive workflow readiness receipt
         run: ota receipt --workflow 'verify' --mode container --archive --json
   ota_ota_refusal_canary_task_selfhost_up:
     name: 'ota.refusal-canary.task.selfhost-up (linux/container)'

--- a/.github/workflows/ota-verify-container-linux.yml
+++ b/.github/workflows/ota-verify-container-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:40a3f00e0000a3a6c91fdf8368bcc3ecdcbff17f1abb38822aea9706395ac3b8
+# ota:managed-github-projection v1 identity=sha256:8b4df2b46b55d84d46151a25309cc1df8aab6bfce1304a0a69f613cb7e7bc066
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-container-linux.yml
+++ b/.github/workflows/ota-verify-container-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:5c341edd074591c3bc6c46797f0842107e6a6f2e17632ad09a5fd130f4908da3
+# ota:managed-github-projection v1 identity=sha256:40a3f00e0000a3a6c91fdf8368bcc3ecdcbff17f1abb38822aea9706395ac3b8
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-container-linux.yml
+++ b/.github/workflows/ota-verify-container-linux.yml
@@ -1,0 +1,67 @@
+# ota:managed-github-projection v1 identity=sha256:4028a3c0a90dac4a9145f995b3ac630a3a4a27630879d8d963c7c2e788b11e29
+name: Ota governance ('verify')
+
+on:
+  workflow_call:
+    inputs:
+      ota_projection_identity:
+        description: Ota-managed projection identity
+        required: true
+        type: string
+      ota_runner:
+        description: GitHub runner selected by the human-owned caller
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+      ota_target_os:
+        description: Target operating system bound into the Ota projection
+        required: true
+        type: string
+
+jobs:
+  ota_ota_verify_verify:
+    name: 'ota.verify.verify (linux/container)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode container --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Validate contract
+        run: ota validate . --json
+      - name: Diagnose contract lane
+        run: ota doctor --workflow 'verify' --mode container --json
+      - name: Discover safe execution surface
+        run: ota tasks --safe --use --json
+      - name: Preview contract lane
+        run: ota up --workflow 'verify' --mode container --agent --dry-run --json
+      - name: Run contract lane
+        run: ota up --workflow 'verify' --mode container --agent --json
+      - name: Archive contract receipt
+        run: ota receipt --workflow 'verify' --mode container --archive --json
+  ota_ota_refusal_canary_task_selfhost_up:
+    name: 'ota.refusal-canary.task.selfhost-up (linux/container)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode container --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota run --agent --expect-refusal --mode container --json 'selfhost:up'
+  ota_ota_refusal_canary_workflow_selfhost:
+    name: 'ota.refusal-canary.workflow.selfhost (linux/container)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode container --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota up --agent --expect-refusal --workflow 'selfhost' --mode container --json

--- a/.github/workflows/ota-verify-native-linux.yml
+++ b/.github/workflows/ota-verify-native-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:ee3835bb4c532fd11a8d8082ab1eb10d0a8ee0f3fb2841a6480979c725dc768a
+# ota:managed-github-projection v1 identity=sha256:4483dd3e4d051145537fcf50005f87666a063f7b0d15c2a56bb24318ba91e6fe
 name: Ota governance ('verify')
 
 on:
@@ -27,6 +27,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Validate contract
@@ -37,9 +41,9 @@ jobs:
         run: ota tasks --safe --use --json
       - name: Preview contract lane
         run: ota up --workflow 'verify' --mode native --agent --dry-run --json
-      - name: Run contract lane
-        run: ota up --workflow 'verify' --mode native --agent --json
-      - name: Archive contract receipt
+      - name: Execute finite contract task
+        run: ota run 'verify' --mode native --agent
+      - name: Archive workflow readiness receipt
         run: ota receipt --workflow 'verify' --mode native --archive --json
   ota_ota_refusal_canary_task_selfhost_up:
     name: 'ota.refusal-canary.task.selfhost-up (linux/native)'
@@ -49,6 +53,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Prove agent refusal canary
@@ -61,6 +69,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Prove agent refusal canary

--- a/.github/workflows/ota-verify-native-linux.yml
+++ b/.github/workflows/ota-verify-native-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:f84e2ea06ac5eaee2d5c2eb26995c4d4cb23f19d42030467abf9617d3ae8f5aa
+# ota:managed-github-projection v1 identity=sha256:762e2558c7e97efd8603451e1c69709b9d54523744f50af592a1a94eb56b1a87
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-linux.yml
+++ b/.github/workflows/ota-verify-native-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:762e2558c7e97efd8603451e1c69709b9d54523744f50af592a1a94eb56b1a87
+# ota:managed-github-projection v1 identity=sha256:90a79930b370ff46b5db7035e0087d45938c78a80c0cde7fad8e35325e2f1784
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-linux.yml
+++ b/.github/workflows/ota-verify-native-linux.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:4483dd3e4d051145537fcf50005f87666a063f7b0d15c2a56bb24318ba91e6fe
+# ota:managed-github-projection v1 identity=sha256:f84e2ea06ac5eaee2d5c2eb26995c4d4cb23f19d42030467abf9617d3ae8f5aa
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-linux.yml
+++ b/.github/workflows/ota-verify-native-linux.yml
@@ -1,0 +1,67 @@
+# ota:managed-github-projection v1 identity=sha256:ee3835bb4c532fd11a8d8082ab1eb10d0a8ee0f3fb2841a6480979c725dc768a
+name: Ota governance ('verify')
+
+on:
+  workflow_call:
+    inputs:
+      ota_projection_identity:
+        description: Ota-managed projection identity
+        required: true
+        type: string
+      ota_runner:
+        description: GitHub runner selected by the human-owned caller
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+      ota_target_os:
+        description: Target operating system bound into the Ota projection
+        required: true
+        type: string
+
+jobs:
+  ota_ota_verify_verify:
+    name: 'ota.verify.verify (linux/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Validate contract
+        run: ota validate . --json
+      - name: Diagnose contract lane
+        run: ota doctor --workflow 'verify' --mode native --json
+      - name: Discover safe execution surface
+        run: ota tasks --safe --use --json
+      - name: Preview contract lane
+        run: ota up --workflow 'verify' --mode native --agent --dry-run --json
+      - name: Run contract lane
+        run: ota up --workflow 'verify' --mode native --agent --json
+      - name: Archive contract receipt
+        run: ota receipt --workflow 'verify' --mode native --archive --json
+  ota_ota_refusal_canary_task_selfhost_up:
+    name: 'ota.refusal-canary.task.selfhost-up (linux/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota run --agent --expect-refusal --mode native --json 'selfhost:up'
+  ota_ota_refusal_canary_workflow_selfhost:
+    name: 'ota.refusal-canary.workflow.selfhost (linux/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota up --agent --expect-refusal --workflow 'selfhost' --mode native --json

--- a/.github/workflows/ota-verify-native-macos.yml
+++ b/.github/workflows/ota-verify-native-macos.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:cc187bf7de2f5e1eb9184f5fff62f87cbae7624df902a6dd64aeabc0b710fda5
+# ota:managed-github-projection v1 identity=sha256:283e11795584f0391bebe1f9b7aff68e17e70e9fd36c376ed00c013728ae4264
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-macos.yml
+++ b/.github/workflows/ota-verify-native-macos.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:a8277aa9c1cf6ce81e0b6466c61d12eea654ceda56b25bb2c4322d3e1e25c186
+# ota:managed-github-projection v1 identity=sha256:cc187bf7de2f5e1eb9184f5fff62f87cbae7624df902a6dd64aeabc0b710fda5
 name: Ota governance ('verify')
 
 on:
@@ -27,6 +27,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Validate contract
@@ -37,9 +41,9 @@ jobs:
         run: ota tasks --safe --use --json
       - name: Preview contract lane
         run: ota up --workflow 'verify' --mode native --agent --dry-run --json
-      - name: Run contract lane
-        run: ota up --workflow 'verify' --mode native --agent --json
-      - name: Archive contract receipt
+      - name: Execute finite contract task
+        run: ota run 'verify' --mode native --agent
+      - name: Archive workflow readiness receipt
         run: ota receipt --workflow 'verify' --mode native --archive --json
   ota_ota_refusal_canary_task_selfhost_up:
     name: 'ota.refusal-canary.task.selfhost-up (macos/native)'
@@ -49,6 +53,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Prove agent refusal canary
@@ -61,6 +69,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Prove agent refusal canary

--- a/.github/workflows/ota-verify-native-macos.yml
+++ b/.github/workflows/ota-verify-native-macos.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:0db3ef741dbc7a53feea9c457b0b89e27c3caa3d634ae2d5e504cacd959081e0
+# ota:managed-github-projection v1 identity=sha256:b154aa6d4330908e29470ec4e79ee8222efe796d7cbea290b19f6e22ac4f3944
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-macos.yml
+++ b/.github/workflows/ota-verify-native-macos.yml
@@ -1,0 +1,67 @@
+# ota:managed-github-projection v1 identity=sha256:a8277aa9c1cf6ce81e0b6466c61d12eea654ceda56b25bb2c4322d3e1e25c186
+name: Ota governance ('verify')
+
+on:
+  workflow_call:
+    inputs:
+      ota_projection_identity:
+        description: Ota-managed projection identity
+        required: true
+        type: string
+      ota_runner:
+        description: GitHub runner selected by the human-owned caller
+        required: false
+        default: 'macos-latest'
+        type: string
+      ota_target_os:
+        description: Target operating system bound into the Ota projection
+        required: true
+        type: string
+
+jobs:
+  ota_ota_verify_verify:
+    name: 'ota.verify.verify (macos/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Validate contract
+        run: ota validate . --json
+      - name: Diagnose contract lane
+        run: ota doctor --workflow 'verify' --mode native --json
+      - name: Discover safe execution surface
+        run: ota tasks --safe --use --json
+      - name: Preview contract lane
+        run: ota up --workflow 'verify' --mode native --agent --dry-run --json
+      - name: Run contract lane
+        run: ota up --workflow 'verify' --mode native --agent --json
+      - name: Archive contract receipt
+        run: ota receipt --workflow 'verify' --mode native --archive --json
+  ota_ota_refusal_canary_task_selfhost_up:
+    name: 'ota.refusal-canary.task.selfhost-up (macos/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota run --agent --expect-refusal --mode native --json 'selfhost:up'
+  ota_ota_refusal_canary_workflow_selfhost:
+    name: 'ota.refusal-canary.workflow.selfhost (macos/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota up --agent --expect-refusal --workflow 'selfhost' --mode native --json

--- a/.github/workflows/ota-verify-native-macos.yml
+++ b/.github/workflows/ota-verify-native-macos.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:283e11795584f0391bebe1f9b7aff68e17e70e9fd36c376ed00c013728ae4264
+# ota:managed-github-projection v1 identity=sha256:0db3ef741dbc7a53feea9c457b0b89e27c3caa3d634ae2d5e504cacd959081e0
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-windows.yml
+++ b/.github/workflows/ota-verify-native-windows.yml
@@ -1,0 +1,67 @@
+# ota:managed-github-projection v1 identity=sha256:aa52e2760d9d73724de802ec62bbe027864485e59a82fdf63732430ab1fb4383
+name: Ota governance ('verify')
+
+on:
+  workflow_call:
+    inputs:
+      ota_projection_identity:
+        description: Ota-managed projection identity
+        required: true
+        type: string
+      ota_runner:
+        description: GitHub runner selected by the human-owned caller
+        required: false
+        default: 'windows-latest'
+        type: string
+      ota_target_os:
+        description: Target operating system bound into the Ota projection
+        required: true
+        type: string
+
+jobs:
+  ota_ota_verify_verify:
+    name: 'ota.verify.verify (windows/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Validate contract
+        run: ota validate . --json
+      - name: Diagnose contract lane
+        run: ota doctor --workflow 'verify' --mode native --json
+      - name: Discover safe execution surface
+        run: ota tasks --safe --use --json
+      - name: Preview contract lane
+        run: ota up --workflow 'verify' --mode native --agent --dry-run --json
+      - name: Run contract lane
+        run: ota up --workflow 'verify' --mode native --agent --json
+      - name: Archive contract receipt
+        run: ota receipt --workflow 'verify' --mode native --archive --json
+  ota_ota_refusal_canary_task_selfhost_up:
+    name: 'ota.refusal-canary.task.selfhost-up (windows/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota run --agent --expect-refusal --mode native --json 'selfhost:up'
+  ota_ota_refusal_canary_workflow_selfhost:
+    name: 'ota.refusal-canary.workflow.selfhost (windows/native)'
+    runs-on: ${{ inputs.ota_runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
+        with:
+          source: contract
+      - name: Verify Ota projection identity
+        run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
+      - name: Prove agent refusal canary
+        run: ota up --agent --expect-refusal --workflow 'selfhost' --mode native --json

--- a/.github/workflows/ota-verify-native-windows.yml
+++ b/.github/workflows/ota-verify-native-windows.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:aa52e2760d9d73724de802ec62bbe027864485e59a82fdf63732430ab1fb4383
+# ota:managed-github-projection v1 identity=sha256:70a69e93fece567b9c14fb63c7130c4ba98e7e6cc0e290d4bdbe7c016f8e44b0
 name: Ota governance ('verify')
 
 on:
@@ -27,6 +27,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Validate contract
@@ -37,9 +41,9 @@ jobs:
         run: ota tasks --safe --use --json
       - name: Preview contract lane
         run: ota up --workflow 'verify' --mode native --agent --dry-run --json
-      - name: Run contract lane
-        run: ota up --workflow 'verify' --mode native --agent --json
-      - name: Archive contract receipt
+      - name: Execute finite contract task
+        run: ota run 'verify' --mode native --agent
+      - name: Archive workflow readiness receipt
         run: ota receipt --workflow 'verify' --mode native --archive --json
   ota_ota_refusal_canary_task_selfhost_up:
     name: 'ota.refusal-canary.task.selfhost-up (windows/native)'
@@ -49,6 +53,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Prove agent refusal canary
@@ -61,6 +69,10 @@ jobs:
       - uses: ota-run/setup@493cba84bf7f7c11c9e8e996d832d93a89c62184
         with:
           source: contract
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '>=22'
+          package-manager-cache: false
       - name: Verify Ota projection identity
         run: ota ci projection --workflow 'verify' --mode native --target-os ${{ inputs.ota_target_os }} --expect-identity ${{ inputs.ota_projection_identity }} --json
       - name: Prove agent refusal canary

--- a/.github/workflows/ota-verify-native-windows.yml
+++ b/.github/workflows/ota-verify-native-windows.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:e3fbeb038a40296aaba67a7c5bd987db66f0ea08bc2aed35a32012b430c7cb40
+# ota:managed-github-projection v1 identity=sha256:365fa1b76ef98cd81c2a8586916188d5c0bf47659a889cb6f576cea3b203acf4
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-windows.yml
+++ b/.github/workflows/ota-verify-native-windows.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:365fa1b76ef98cd81c2a8586916188d5c0bf47659a889cb6f576cea3b203acf4
+# ota:managed-github-projection v1 identity=sha256:b3f5da2f77c0148800fda5410ef84c23924ac22385ed82ba34537cb80a86f8c5
 name: Ota governance ('verify')
 
 on:

--- a/.github/workflows/ota-verify-native-windows.yml
+++ b/.github/workflows/ota-verify-native-windows.yml
@@ -1,4 +1,4 @@
-# ota:managed-github-projection v1 identity=sha256:70a69e93fece567b9c14fb63c7130c4ba98e7e6cc0e290d4bdbe7c016f8e44b0
+# ota:managed-github-projection v1 identity=sha256:e3fbeb038a40296aaba67a7c5bd987db66f0ea08bc2aed35a32012b430c7cb40
 name: Ota governance ('verify')
 
 on:

--- a/.ota/pressure-replay-policy.yaml
+++ b/.ota/pressure-replay-policy.yaml
@@ -1,16 +1,3 @@
-#                █████
-#               ░░███
-#       ██████  ███████    ██████
-#      ███░░███░░░███░    ░░░░░███
-#     ░███ ░███  ░███      ███████
-#     ░███ ░███  ░███ ███ ███░░███
-#     ░░██████   ░░█████ ░░████████
-#      ░░░░░░     ░░░░░   ░░░░░░░░
-#
-#   Copyright (C) 2026 — 2026, Ota. All Rights Reserved.
-#
-#   Licensed under the Apache License, Version 2.0. See LICENSE for the full license text.
-
 policies:
   replay_inputs:
     identity:

--- a/.ota/pressure-replay-policy.yaml
+++ b/.ota/pressure-replay-policy.yaml
@@ -1,0 +1,19 @@
+#                █████
+#               ░░███
+#       ██████  ███████    ██████
+#      ███░░███░░░███░    ░░░░░███
+#     ░███ ░███  ░███      ███████
+#     ░███ ░███  ░███ ███ ███░░███
+#     ░░██████   ░░█████ ░░████████
+#      ░░░░░░     ░░░░░   ░░░░░░░░
+#
+#   Copyright (C) 2026 — 2026, Ota. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0. See LICENSE for the full license text.
+
+policies:
+  replay_inputs:
+    identity:
+      workflows:
+        verify:
+          on_insufficient: deny

--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ pnpm dev
 
 Open **http://localhost:3005**.
 
+## Ota
+
+This repository includes an [`ota.yaml`](./ota.yaml) contract for contributor setup, deterministic
+verification, the SQLite development runtime, and the self-hosted Compose boundary. Install Ota
+from the [official installation guide](https://ota.run/docs/install), then inspect the declared
+surface before running a task.
+
+```bash
+# validate the contract and inspect readiness
+ota validate .
+ota doctor
+
+# discover human and agent-safe task usage
+ota tasks --use
+ota tasks --safe --use
+
+# run the finite verification workflow on the host
+ota up --workflow verify --mode native
+
+# run the same portable verification workflow in Ota's container boundary
+ota up --workflow verify --mode container
+
+# start the contributor SQLite runtime
+ota up --workflow sqlite-dev
+```
+
+The `selfhost` workflow owns the documented Compose lifecycle, but it does not claim the
+interactive Appwrite setup wizard or schema provisioning. Inspect that workflow before running it.
+
 ## Stack
 
 Next.js · React · TypeScript · Appwrite · Tailwind

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ const eslintConfig = [
       "**/generated/**",
       "functions/**",
       ".repo/**",
+      ".agents/**",
     ],
   },
   ...nextConfigs,

--- a/ota.yaml
+++ b/ota.yaml
@@ -396,8 +396,8 @@ agent:
     ota:
       note: Only install Ota if it is missing and installation is approved.
       source:
-        kind: branch
-        branch: 1.6.25-implementation
+        kind: version
+        version: v1.6.24
   entrypoint: setup
   default_task: verify
   safe_tasks: [setup, test, lint, build, verify]

--- a/ota.yaml
+++ b/ota.yaml
@@ -372,6 +372,8 @@ workflows:
   sqlite-dev:
     intent: local_development
     description: Prepare the deterministic offline SQLite profile and start the local Next.js runtime
+    proof:
+      claim: bounded
     setup:
       task: setup
     run:

--- a/ota.yaml
+++ b/ota.yaml
@@ -195,6 +195,10 @@ tasks:
 
   verify:
     description: Run the complete finite SQLite-backed verification surface
+    replay_inputs:
+      - id: pnpm_lockfile
+        kind: static_file
+        path: pnpm-lock.yaml
     aggregate:
       tasks: [test, lint, build]
     safe_for_agent: true
@@ -400,8 +404,8 @@ agent:
     ota:
       note: Install the active Ota pressure branch so native and container governance checks exercise the same unreleased runner truth.
       source:
-        kind: branch
-        branch: 1.6.25-implementation
+        kind: git_rev
+        rev: f97b96cc8437fe9e58736cc83422c8bf8e7d4636
   entrypoint: setup
   default_task: verify
   safe_tasks: [setup, test, lint, build, verify]
@@ -430,6 +434,7 @@ agent:
   exceptions:
     sensitive_writes: [.env]
   protected_paths:
+    - .ota/pressure-replay-policy.yaml
     - .github/workflows
     - AGENTS.md
     - docker-compose.app-only.yml

--- a/ota.yaml
+++ b/ota.yaml
@@ -396,8 +396,8 @@ agent:
     ota:
       note: Only install Ota if it is missing and installation is approved.
       source:
-        kind: version
-        version: v1.6.24
+        kind: branch
+        branch: 1.6.25-implementation
   entrypoint: setup
   default_task: verify
   safe_tasks: [setup, test, lint, build, verify]

--- a/ota.yaml
+++ b/ota.yaml
@@ -402,10 +402,10 @@ workflows:
 agent:
   bootstrap:
     ota:
-      note: Install the active Ota pressure branch so native and container governance checks exercise the same unreleased runner truth.
+      note: Only install Ota if it is missing and installation is approved.
       source:
-        kind: git_rev
-        rev: f97b96cc8437fe9e58736cc83422c8bf8e7d4636
+        kind: version
+        version: v1.6.25
   entrypoint: setup
   default_task: verify
   safe_tasks: [setup, test, lint, build, verify]

--- a/ota.yaml
+++ b/ota.yaml
@@ -374,6 +374,8 @@ workflows:
     description: Prepare the deterministic offline SQLite profile and start the local Next.js runtime
     proof:
       claim: bounded
+    readiness:
+      surfaces: [contributor:web]
     setup:
       task: setup
     run:

--- a/ota.yaml
+++ b/ota.yaml
@@ -394,13 +394,16 @@ workflows:
 agent:
   bootstrap:
     ota:
-      note: Only install Ota if it is missing and installation is approved.
+      note: Install the active Ota pressure branch so native and container governance checks exercise the same unreleased runner truth.
       source:
         kind: branch
         branch: 1.6.25-implementation
   entrypoint: setup
   default_task: verify
   safe_tasks: [setup, test, lint, build, verify]
+  refusal_canaries:
+    - task: selfhost:up
+    - workflow: selfhost
   verify_after_changes: [verify]
   writable_paths:
     - .env
@@ -438,3 +441,6 @@ agent:
     Appwrite schema provisioning are intentionally outside this contract because they require
     operator credentials. Use `ota up --workflow selfhost` for the documented full Compose
     topology; it is intentionally not agent-callable and does not claim schema provisioning.
+    `selfhost:up` and the `selfhost` workflow are refusal canaries: run
+    `ota run --agent --expect-refusal selfhost:up` or
+    `ota up --agent --expect-refusal --workflow selfhost` to prove that boundary remains live.


### PR DESCRIPTION
## What changed

- pin the contract bootstrap to released Ota `v1.6.25`
- add runner-enforced refusal canaries for the unsafe self-host task and workflow
- add Ota-managed verification projections for Linux, macOS, Windows, and Linux container execution
- add a strict replay-input policy negative control that proves refusal before setup, execution, or Doctor mutation
- bind the SQLite development workflow to its declared readiness surface
- document the Ota contributor path in the README

## Validation

Validated locally with the published Ota `v1.6.25` binary (`a3e9f98f3`):

- `ota validate`
- `ota doctor --workflow verify` in native and container modes
- `ota tasks --use` and `ota tasks --safe --use`
- public task and workflow dry-run coverage
- native and container `verify` execution
- task and workflow refusal canaries in native and container modes
- strict replay-input denial across Doctor, dry-run, real execution, and `doctor --fix`
- all four `ota ci github check` projections
- `actionlint`

Hosted draft-PR checks remain authoritative for the Ubuntu, macOS, Windows, and container matrix.

## Boundaries

The self-hosted workflow governs the documented Compose lifecycle, not the interactive Appwrite setup wizard or schema provisioning. Direct standalone Compose task previews also depend on the generated `.ota/kylrix.selfhost.env`; the contract-owned workflow remains the supported pre-materialization preview path.

## Hosted evidence

- [Released-v1.6.25 Ota matrix](https://github.com/bobaikato/kylrix/actions/runs/30493468104): green at exact head `4570b4e3` across native Linux/macOS/Windows, Linux container, bounded runtime proof, generated governance checks, refusal canaries, and strict replay-input refusal. The upstream PR run exposed one intermittent container runtime-proof failure while its generated container verification passed; the exact-head fork rerun passed that same proof, so the PR remains draft while the Ota runtime-proof transaction instability is tracked.