### PR TITLE
Boost Settings > Admin UI & integrate account-scoped LocalEngine backing

### DIFF
--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,0 +1,4 @@
+// Setup file for vitest
+import { vi } from 'vitest';
+
+// Global test setup if needed

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1258,11 +1258,51 @@ function SettingsPageInner() {
                 {activeTab === 'admin' && isAdmin && (
                     <div className="flex flex-col lg:flex-row gap-6 pb-24 w-full">
                         {/* Admin sub-menu */}
-                        <div className="flex flex-col gap-2 w-full lg:w-[200px] flex-shrink-0">
-                            <button type="button" onClick={() => setAdminSubTab('dashboard')} className={`p-3.5 rounded-xl text-xs font-bold text-left cursor-pointer transition-colors ${adminSubTab === 'dashboard' ? 'bg-[#6366F1]/10 text-[#6366F1] border border-[#6366F1]/20' : 'text-white/40 hover:bg-white/5'}`}>System Dashboard</button>
-                            <button type="button" onClick={() => setAdminSubTab('users')} className={`p-3.5 rounded-xl text-xs font-bold text-left cursor-pointer transition-colors ${adminSubTab === 'users' ? 'bg-[#6366F1]/10 text-[#6366F1] border border-[#6366F1]/20' : 'text-white/40 hover:bg-white/5'}`}>User Directory</button>
-                            <button type="button" onClick={() => setAdminSubTab('email')} className={`p-3.5 rounded-xl text-xs font-bold text-left cursor-pointer transition-colors ${adminSubTab === 'email' ? 'bg-[#6366F1]/10 text-[#6366F1] border border-[#6366F1]/20' : 'text-white/40 hover:bg-white/5'}`}>Email Orchestrator</button>
-                            <button type="button" onClick={() => setAdminSubTab('coupons')} className={`p-3.5 rounded-xl text-xs font-bold text-left cursor-pointer transition-colors ${adminSubTab === 'coupons' ? 'bg-[#6366F1]/10 text-[#6366F1] border border-[#6366F1]/20' : 'text-white/40 hover:bg-white/5'}`}>Coupons Registry</button>
+                        <div className="p-2 bg-[#000000] border-2 border-white/20 rounded-2xl shadow-xl flex flex-col gap-1.5 w-full lg:w-[220px] flex-shrink-0 self-start">
+                            <button
+                                type="button"
+                                onClick={() => setAdminSubTab('dashboard')}
+                                className={`flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl text-xs font-extrabold transition-all text-left w-full cursor-pointer ${
+                                    adminSubTab === 'dashboard'
+                                        ? 'bg-[#6366F1] text-white border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)]'
+                                        : 'text-white/70 hover:text-white hover:bg-white/[0.06] border-2 border-transparent hover:border-white/20'
+                                }`}
+                            >
+                                System Dashboard
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setAdminSubTab('users')}
+                                className={`flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl text-xs font-extrabold transition-all text-left w-full cursor-pointer ${
+                                    adminSubTab === 'users'
+                                        ? 'bg-[#6366F1] text-white border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)]'
+                                        : 'text-white/70 hover:text-white hover:bg-white/[0.06] border-2 border-transparent hover:border-white/20'
+                                }`}
+                            >
+                                User Directory
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setAdminSubTab('email')}
+                                className={`flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl text-xs font-extrabold transition-all text-left w-full cursor-pointer ${
+                                    adminSubTab === 'email'
+                                        ? 'bg-[#6366F1] text-white border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)]'
+                                        : 'text-white/70 hover:text-white hover:bg-white/[0.06] border-2 border-transparent hover:border-white/20'
+                                }`}
+                            >
+                                Email Orchestrator
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setAdminSubTab('coupons')}
+                                className={`flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl text-xs font-extrabold transition-all text-left w-full cursor-pointer ${
+                                    adminSubTab === 'coupons'
+                                        ? 'bg-[#6366F1] text-white border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)]'
+                                        : 'text-white/70 hover:text-white hover:bg-white/[0.06] border-2 border-transparent hover:border-white/20'
+                                }`}
+                            >
+                                Coupons Registry
+                            </button>
                         </div>
                         {/* Render the selected admin subpage */}
                         <div className="flex-grow min-w-0">

--- a/components/admin/AdminCoupons.tsx
+++ b/components/admin/AdminCoupons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import Link from 'next/link';
 import { Copy, RefreshCw, Ticket, Search, Check, X, Loader2 } from 'lucide-react';
 import AdminLayout from '@/components/admin/components/AdminLayout';
@@ -9,7 +9,8 @@ import { getAdminUserByIdAction, searchAdminUserByIdAction, searchAdminUserByEma
 import { useAuth } from '@/context/auth/AuthContext';
 import { useUnifiedDrawer } from '@/context/UnifiedDrawerContext';
 import { AppwriteService } from '@/lib/appwrite';
-
+import { LocalEngine } from '@/lib/services/LocalEngine';
+import { getAdminCouponsCacheKey } from '@/lib/admin/admin-cache';
 
 type CouponRow = {
   $id: string;
@@ -47,7 +48,7 @@ export default function AdminCouponsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-  const { getJWT } = useAuth();
+  const { user, getJWT } = useAuth();
   
   const [profileQuery, setProfileQuery] = useState('');
   const [searchResults, setSearchResults] = useState<any[]>([]);
@@ -66,23 +67,32 @@ export default function AdminCouponsPage() {
     months: '1',
     planId: 'PRO_MONTH'});
 
-  const loadCoupons = async () => {
+  const loadCoupons = useCallback(async (force = false) => {
+    const cacheKey = getAdminCouponsCacheKey(user?.$id);
+    if (!cacheKey) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
       const jwt = await getJWT();
-      const rows = await listCouponsAction(jwt || undefined);
+      const rows = await LocalEngine.query(
+        cacheKey,
+        async () => await listCouponsAction(jwt || undefined),
+        { ttl: 5 * 60 * 1000, force }
+      );
       setCoupons(rows as any[]);
     } catch (err: any) {
       setError(err?.message || 'Failed to load coupons');
     } finally {
       setLoading(false);
     }
-  };
+  }, [user?.$id, getJWT]);
 
   useEffect(() => {
     loadCoupons();
-  }, [getJWT]);
+  }, [loadCoupons]);
 
   useEffect(() => {
     let active = true;
@@ -212,7 +222,9 @@ export default function AdminCouponsPage() {
         planId: 'PRO_MONTH'
       }));
       setSelectedTargets([]);
-      await loadCoupons();
+      const cacheKey = getAdminCouponsCacheKey(user?.$id);
+      if (cacheKey) await LocalEngine.cacheDelete(cacheKey);
+      await loadCoupons(true);
     } catch (err: any) {
       setError(err?.message || 'Failed to create coupon');
     } finally {
@@ -239,7 +251,9 @@ export default function AdminCouponsPage() {
           const jwt = await getJWT();
           await invalidateCouponAction(id, jwt || undefined);
           setSuccess('Coupon revoked successfully.');
-          await loadCoupons();
+          const cacheKey = getAdminCouponsCacheKey(user?.$id);
+          if (cacheKey) await LocalEngine.cacheDelete(cacheKey);
+          await loadCoupons(true);
         } catch (err: any) {
           setError(err?.message || 'Failed to revoke coupon');
         } finally {
@@ -259,14 +273,14 @@ export default function AdminCouponsPage() {
             <h2 className="text-2xl md:text-3xl font-black font-clash text-white tracking-tight leading-tight">
               Coupons
             </h2>
-            <p className="text-sm text-white/45 mt-1">
+            <p className="text-sm font-bold text-white/60 mt-1">
               Create open or targeted coupons. Open coupons are first-claim wins, targeted coupons are restricted to named users.
             </p>
           </div>
           <button
             type="button"
-            onClick={loadCoupons}
-            className="flex items-center gap-1.5 px-4 py-2.5 rounded-full border border-white/10 text-white font-bold text-xs hover:bg-white/5 hover:border-white/20 transition-all cursor-pointer self-start sm:self-auto"
+            onClick={() => loadCoupons(true)}
+            className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border-2 border-white/20 bg-[#000000] text-white font-extrabold text-xs hover:bg-white/10 hover:border-white/40 transition-all cursor-pointer self-start sm:self-auto shadow-lg"
           >
             <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
             <span>Refresh</span>
@@ -274,21 +288,21 @@ export default function AdminCouponsPage() {
         </div>
 
         {error && (
-          <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm font-semibold">
+          <div className="p-4 rounded-xl bg-rose-500/15 border-2 border-rose-500/30 text-rose-400 text-sm font-extrabold">
             {error}
           </div>
         )}
         {success && (
-          <div className="p-4 rounded-xl bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm font-semibold">
+          <div className="p-4 rounded-xl bg-emerald-500/15 border-2 border-emerald-500/30 text-emerald-400 text-sm font-extrabold">
             {success}
           </div>
         )}
 
         {/* Coupon Creator Card */}
-        <div className="p-6 rounded-[28px] bg-[#161412] border border-white/5 flex flex-col gap-5">
+        <div className="p-6 md:p-8 rounded-[28px] bg-[#000000] border-2 border-white/20 flex flex-col gap-5 shadow-2xl">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div className="space-y-1.5 relative col-span-1 md:col-span-2">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Target Users</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Target Users</span>
               {/* Search mode toggle */}
               <div className="flex gap-1.5 mb-2">
                 {(['username', 'userid', 'email'] as const).map((mode) => (
@@ -296,10 +310,10 @@ export default function AdminCouponsPage() {
                     key={mode}
                     type="button"
                     onClick={() => { setSearchMode(mode); setProfileQuery(''); setSearchResults([]); }}
-                    className={`px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider transition-all cursor-pointer ${
+                    className={`px-3 py-1 rounded-lg text-[10px] font-black font-mono uppercase tracking-wider transition-all cursor-pointer ${
                       searchMode === mode
-                        ? 'bg-[#6366F1] text-black'
-                        : 'bg-white/[0.03] border border-white/10 text-white/40 hover:border-[#6366F1]/30 hover:text-white/70'
+                        ? 'bg-[#6366F1] text-white border-2 border-[#6366F1] shadow-[0_0_8px_rgba(99,102,241,0.35)]'
+                        : 'bg-[#000000] border-2 border-white/20 text-white/60 hover:border-white/40 hover:text-white'
                     }`}
                   >
                     {mode === 'username' ? 'Username' : mode === 'userid' ? 'User ID' : 'Email'}
@@ -310,9 +324,9 @@ export default function AdminCouponsPage() {
                 <div className="relative flex-1">
                   <div className="absolute inset-y-0 left-3.5 flex items-center pointer-events-none">
                     {searchingProfiles ? (
-                      <Loader2 size={14} className="text-[#6366F1] animate-spin" />
+                      <Loader2 size={14} className="text-[#818CF8] animate-spin" />
                     ) : (
-                      <Search size={14} className="text-white/40" />
+                      <Search size={14} className="text-white/50" />
                     )}
                   </div>
                   <input
@@ -325,7 +339,7 @@ export default function AdminCouponsPage() {
                     value={profileQuery}
                     onChange={(e) => setProfileQuery(e.target.value)}
                     onKeyDown={(e) => { if (e.key === 'Enter' && searchMode !== 'username') handleManualSearch(); }}
-                    className="w-full bg-[#0A0908] pl-10 pr-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                    className="w-full bg-[#000000] pl-10 pr-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
                   />
                 </div>
                 {searchMode !== 'username' && (
@@ -333,13 +347,13 @@ export default function AdminCouponsPage() {
                     type="button"
                     onClick={handleManualSearch}
                     disabled={!profileQuery.trim() || searchingProfiles}
-                    className="flex items-center gap-1.5 px-4 py-3 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] disabled:opacity-40 text-black font-black text-xs transition-all cursor-pointer"
+                    className="flex items-center gap-1.5 px-4 py-3 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] disabled:opacity-40 text-white font-black text-xs transition-all cursor-pointer border-2 border-[#6366F1]"
                   >
                     {searchingProfiles ? <Loader2 size={14} className="animate-spin" /> : <Search size={14} />}
                   </button>
                 )}
               </div>
-              <span className="text-[10px] text-white/30 block">Leave blank for open claim</span>
+              <span className="text-[10px] text-white/40 font-mono font-bold block">Leave blank for open claim</span>
               
               {/* Search Results Dropdown */}
               {searchResults.length > 0 && (
@@ -348,27 +362,27 @@ export default function AdminCouponsPage() {
                     <div
                       key={p.$id}
                       onClick={() => selectProfile(p)}
-                      className={`flex items-center justify-between gap-4 p-3.5 rounded-xl border transition-all cursor-pointer ${
+                      className={`flex items-center justify-between gap-4 p-3.5 rounded-xl border-2 transition-all cursor-pointer ${
                         selectedTargets.some(t => t.id === p.userId)
-                          ? 'bg-[#6366F1]/10 border-[#6366F1]/25'
-                          : 'bg-white/[0.02] border-white/5 hover:border-[#6366F1]/30 hover:bg-[#6366F1]/5'
+                          ? 'bg-[#6366F1]/20 border-[#6366F1]'
+                          : 'bg-[#000000] border-white/20 hover:border-[#6366F1]/50 hover:bg-[#6366F1]/10'
                       }`}
                     >
                       <div className="flex items-center gap-3 min-w-0">
-                        <div className="w-9 h-9 rounded-xl bg-[#6366F1] text-black font-black flex items-center justify-center text-xs flex-shrink-0">
+                        <div className="w-9 h-9 rounded-xl bg-[#6366F1] text-white font-black flex items-center justify-center text-xs flex-shrink-0 border-2 border-[#6366F1]">
                           {(p.displayName || p.username || '?').charAt(0).toUpperCase()}
                         </div>
                         <div className="min-w-0">
-                          <span className="block text-sm font-extrabold text-white truncate">
+                          <span className="block text-xs font-black text-white truncate">
                             {p.displayName || p.username}
                           </span>
-                          <span className="block text-[11px] text-[#9B9691] font-medium font-mono truncate">
+                          <span className="block text-[11px] text-white/50 font-bold font-mono truncate">
                             @{p.username}
                           </span>
                         </div>
                       </div>
                       {selectedTargets.some(t => t.id === p.userId) ? (
-                        <span className="flex items-center gap-1 px-3 py-1.5 bg-[#6366F1]/20 text-[#6366F1] font-black text-[10px] rounded-lg flex-shrink-0">
+                        <span className="flex items-center gap-1 px-3 py-1.5 bg-[#6366F1]/30 text-white font-black text-[10px] rounded-lg shrink-0 border border-[#6366F1]">
                           <Check size={12} />
                           <span>Added</span>
                         </span>
@@ -379,7 +393,7 @@ export default function AdminCouponsPage() {
                             e.stopPropagation();
                             selectProfile(p);
                           }}
-                          className="flex items-center gap-1 px-3 py-1.5 bg-[#6366F1] hover:bg-[#5458E8] text-black font-black text-[10px] rounded-lg transition-all cursor-pointer flex-shrink-0"
+                          className="flex items-center gap-1 px-3 py-1.5 bg-[#6366F1] hover:bg-[#5254E8] text-white font-black text-[10px] rounded-lg transition-all cursor-pointer shrink-0 border border-[#6366F1]"
                         >
                           <Check size={12} />
                           <span>Select</span>
@@ -394,16 +408,16 @@ export default function AdminCouponsPage() {
               {selectedTargets.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 mt-3 max-h-28 overflow-y-auto">
                   {selectedTargets.map((t) => (
-                    <div key={t.id} className="flex items-center gap-2 pl-1.5 pr-1.5 py-1 rounded-full bg-white/[0.04] border border-white/5">
-                      <div className="w-5 h-5 rounded-full bg-[#6366F1] text-black font-black flex items-center justify-center text-[8px] flex-shrink-0">
+                    <div key={t.id} className="flex items-center gap-2 pl-2 pr-2 py-1 rounded-lg bg-[#000000] border-2 border-[#6366F1]/50">
+                      <div className="w-5 h-5 rounded-md bg-[#6366F1] text-white font-black flex items-center justify-center text-[8px] flex-shrink-0">
                         {(t.name || t.username || '?').charAt(0).toUpperCase()}
                       </div>
-                      <span className="text-[10px] font-bold text-[#6366F1]">@{t.username}</span>
-                      <span className="text-[9px] text-white/40 truncate max-w-[90px]" title={t.email}>{t.email}</span>
+                      <span className="text-[10px] font-black font-mono text-[#818CF8]">@{t.username}</span>
+                      <span className="text-[9px] text-white/50 font-mono truncate max-w-[90px]" title={t.email}>{t.email}</span>
                       <button
                         type="button"
                         onClick={() => removeProfile(t.id)}
-                        className="p-0.5 rounded-full hover:bg-white/10 text-white/40 hover:text-white transition-all cursor-pointer"
+                        className="p-0.5 rounded-full hover:bg-white/10 text-white/50 hover:text-white transition-all cursor-pointer"
                       >
                         <X size={10} />
                       </button>
@@ -414,84 +428,84 @@ export default function AdminCouponsPage() {
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Discount %</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Discount %</span>
               <input
                 type="number"
                 value={form.discountPercent}
                 onChange={(event) => setForm((prev) => ({ ...prev, discountPercent: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               />
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Status</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Status</span>
               <input
                 type="text"
                 value={form.status}
                 onChange={(event) => setForm((prev) => ({ ...prev, status: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               />
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Max Redemptions</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Max Redemptions</span>
               <input
                 type="number"
                 value={form.redemptionLimit}
                 onChange={(event) => setForm((prev) => ({ ...prev, redemptionLimit: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               />
-              <span className="text-[10px] text-white/30 block">Required for open links</span>
+              <span className="text-[10px] text-white/40 font-mono block">Required for open links</span>
             </div>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Title</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Title</span>
               <input
                 type="text"
                 value={form.title}
                 onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               />
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Note</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Note</span>
               <input
                 type="text"
                 value={form.note}
                 onChange={(event) => setForm((prev) => ({ ...prev, note: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               />
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Expires At</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Expires At</span>
               <input
                 type="datetime-local"
                 value={form.expiresAt}
                 onChange={(event) => setForm((prev) => ({ ...prev, expiresAt: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               />
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Active Months</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Active Months</span>
               <input
                 type="number"
                 value={form.months}
                 onChange={(event) => setForm((prev) => ({ ...prev, months: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               />
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Target Plan</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Target Plan</span>
               <select
                 value={form.planId}
                 onChange={(event) => setForm((prev) => ({ ...prev, planId: event.target.value }))}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all font-mono"
               >
                 <option value="PRO_MONTH">Pro Monthly (default)</option>
                 <option value="PRO_YEAR">Pro Yearly</option>
@@ -505,7 +519,7 @@ export default function AdminCouponsPage() {
             type="button"
             onClick={createCoupon}
             disabled={saving}
-            className="flex items-center gap-2 px-5 py-3 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] text-black font-black text-xs transition-all duration-200 cursor-pointer disabled:opacity-50 w-fit"
+            className="flex items-center gap-2 px-5 py-3 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] text-white font-black text-xs transition-all duration-200 cursor-pointer disabled:opacity-50 border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)] w-fit"
           >
             <Ticket size={16} />
             <span>{saving ? 'Creating...' : 'Create Coupon'}</span>
@@ -513,59 +527,59 @@ export default function AdminCouponsPage() {
         </div>
 
         <div className="flex items-center justify-between">
-          <span className="text-white/50 text-sm">{totalCoupons} coupons</span>
+          <span className="text-white/60 font-mono font-bold text-xs">{totalCoupons} coupons registered</span>
         </div>
 
         {/* Coupons List */}
         <div className="space-y-4">
-          {loading ? (
+          {loading && coupons.length === 0 ? (
             <div className="flex justify-center items-center py-16">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#6366F1]" />
             </div>
           ) : coupons.length ? (
             coupons.map((coupon) => (
-              <div key={coupon.$id} className="p-6 rounded-[28px] bg-[#161412] border border-white/5 flex flex-col gap-4">
+              <div key={coupon.$id} className="p-6 rounded-[28px] bg-[#000000] border-2 border-white/20 flex flex-col gap-4 shadow-2xl">
                 <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
                   <div>
-                    <h4 className="font-extrabold text-base text-white">
+                    <h4 className="font-black text-base text-white">
                       {parseMetadata(coupon.metadata)?.coupon?.title || coupon.$id}
                     </h4>
-                    <p className="text-xs text-white/40 mt-1 font-mono">
+                    <p className="text-xs text-white/50 mt-1 font-mono font-bold">
                       /billing/coupon/{coupon.$id}
                     </p>
                     {coupon.$createdAt && (
-                      <p className="text-[10px] text-white/30 mt-1 font-mono">
+                      <p className="text-[10px] text-white/40 mt-1 font-mono">
                         Issued: {new Date(coupon.$createdAt).toLocaleString()}
                       </p>
                     )}
                   </div>
                   <div className="flex flex-wrap gap-2">
-                    <span className="px-2.5 py-0.5 rounded text-[10px] font-black uppercase tracking-wider border bg-white/5 border-white/10 text-white/60">
+                    <span className="px-2.5 py-1 rounded-md text-[10px] font-black font-mono uppercase tracking-wider border-2 bg-white/10 border-white/20 text-white/70">
                       {(coupon as any).redemptionCount || 0} / {(coupon as any).redemptionLimit || 1} uses
                     </span>
-                    <span className={`px-2.5 py-0.5 rounded text-[10px] font-black uppercase tracking-wider border ${
+                    <span className={`px-2.5 py-1 rounded-md text-[10px] font-black font-mono uppercase tracking-wider border-2 ${
                       formatScope(coupon) === 'open' 
-                        ? 'bg-blue-500/10 border-blue-500/20 text-blue-400' 
-                        : 'bg-white/5 border-white/10 text-white/40'
+                        ? 'bg-blue-500/15 border-blue-500/30 text-blue-400'
+                        : 'bg-white/10 border-white/20 text-white/60'
                     }`}>
                       {formatScope(coupon)}
                     </span>
-                    <span className="px-2.5 py-0.5 rounded text-[10px] font-black uppercase tracking-wider border bg-indigo-500/10 border-indigo-500/20 text-indigo-400">
+                    <span className="px-2.5 py-1 rounded-md text-[10px] font-black font-mono uppercase tracking-wider border-2 bg-[#6366F1]/15 border-[#6366F1]/30 text-[#818CF8]">
                       {coupon.discountPercent || parseMetadata(coupon.metadata)?.coupon?.discountPercent || 0}% Off
                     </span>
-                    <span className="px-2.5 py-0.5 rounded text-[10px] font-black uppercase tracking-wider border bg-amber-500/10 border-amber-500/20 text-amber-400">
+                    <span className="px-2.5 py-1 rounded-md text-[10px] font-black font-mono uppercase tracking-wider border-2 bg-amber-500/15 border-amber-500/30 text-amber-400">
                       {parseMetadata(coupon.metadata)?.planId || 'PRO_MONTH'}
                     </span>
-                    <span className="px-2.5 py-0.5 rounded text-[10px] font-black uppercase tracking-wider border bg-emerald-500/10 border-emerald-500/20 text-emerald-400">
+                    <span className="px-2.5 py-1 rounded-md text-[10px] font-black font-mono uppercase tracking-wider border-2 bg-emerald-500/15 border-emerald-500/30 text-emerald-400">
                       {parseMetadata(coupon.metadata)?.months || 1} Month(s)
                     </span>
-                    <span className="px-2.5 py-0.5 rounded text-[10px] font-black uppercase tracking-wider border bg-white/5 border-white/10 text-white/60">
+                    <span className="px-2.5 py-1 rounded-md text-[10px] font-black font-mono uppercase tracking-wider border-2 bg-white/10 border-white/20 text-white/70">
                       {String(coupon.status || 'active')}
                     </span>
                   </div>
                 </div>
 
-                <p className="text-sm text-white/65 leading-relaxed">
+                <p className="text-xs font-bold text-white/70 leading-relaxed font-mono">
                   {parseMetadata(coupon.metadata)?.note || 'No note provided.'}
                 </p>
 
@@ -573,14 +587,14 @@ export default function AdminCouponsPage() {
                   <button
                     type="button"
                     onClick={() => copyLink(coupon.$id)}
-                    className="flex items-center gap-1.5 px-4 py-2.5 rounded-full border border-white/10 text-white font-bold text-xs hover:bg-white/5 hover:border-white/20 transition-all cursor-pointer"
+                    className="flex items-center gap-1.5 px-4 py-2 rounded-xl border-2 border-white/20 text-white font-extrabold text-xs hover:bg-white/10 hover:border-white/40 transition-all cursor-pointer bg-[#000000]"
                   >
                     <Copy size={14} />
                     <span>Copy Link</span>
                   </button>
                   <Link
                     href={`/billing/coupon/${coupon.$id}`}
-                    className="px-4 py-2.5 rounded-full text-xs font-black text-[#6366F1] hover:text-[#5254E8] transition-colors cursor-pointer"
+                    className="px-4 py-2 rounded-xl text-xs font-black text-[#818CF8] hover:text-white transition-colors cursor-pointer font-mono uppercase tracking-wider"
                   >
                     Open Coupon Page
                   </Link>
@@ -588,7 +602,7 @@ export default function AdminCouponsPage() {
                     <button
                       type="button"
                       onClick={() => revokeCoupon(coupon.$id)}
-                      className="px-4 py-2.5 rounded-full text-xs font-black text-red-500 hover:text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer ml-auto"
+                      className="px-4 py-2 rounded-xl text-xs font-black text-rose-400 hover:text-rose-300 hover:bg-rose-500/10 transition-colors cursor-pointer ml-auto border-2 border-rose-500/30"
                     >
                       Revoke
                     </button>
@@ -597,7 +611,7 @@ export default function AdminCouponsPage() {
               </div>
             ))
           ) : (
-            <div className="p-8 rounded-[28px] bg-[#161412] border border-white/5 text-center text-sm text-white/55">
+            <div className="p-8 rounded-[28px] bg-[#000000] border-2 border-white/20 text-center text-xs font-black font-mono text-white/50 shadow-2xl">
               No coupons yet.
             </div>
           )}

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { 
   Users, 
@@ -14,18 +14,28 @@ import {
 import AdminLayout from '@/components/admin/components/AdminLayout';
 import { getAdminStatsAction } from '@/lib/actions/billing/admin';
 import { useAuth } from '@/context/auth/AuthContext';
-
+import { LocalEngine } from '@/lib/services/LocalEngine';
+import { getAdminStatsCacheKey } from '@/lib/admin/admin-cache';
 
 export default function AdminDashboard() {
   const [stats, setStats] = useState<any>(null);
   const [loading, setLoading] = useState(true);
-  const { getJWT } = useAuth();
+  const { user, getJWT } = useAuth();
 
-  const fetchStats = async () => {
+  const fetchStats = useCallback(async (force = false) => {
+    const cacheKey = getAdminStatsCacheKey(user?.$id);
+    if (!cacheKey) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     try {
       const jwt = await getJWT();
-      const data = await getAdminStatsAction(jwt || undefined);
+      const data = await LocalEngine.query(
+        cacheKey,
+        async () => await getAdminStatsAction(jwt || undefined),
+        { ttl: 5 * 60 * 1000, force }
+      );
       setStats(data);
     } catch (error: any) {
       console.error('Failed to fetch stats:', error);
@@ -33,17 +43,17 @@ export default function AdminDashboard() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user?.$id, getJWT]);
 
   useEffect(() => {
     fetchStats();
-  }, [getJWT]);
+  }, [fetchStats]);
 
   const statCards = [
-    { label: 'Total Users', value: stats?.totalUsers || '0', icon: Users, color: 'text-indigo-400', bgColor: 'bg-indigo-500/10', borderColor: 'hover:border-indigo-500/30', trend: stats?.growth || '+0%' },
-    { label: 'Active Sessions', value: stats?.activeNow || '0', icon: Activity, color: 'text-emerald-400', bgColor: 'bg-emerald-500/10', borderColor: 'hover:border-emerald-500/30', trend: '+5%' },
-    { label: 'API Requests', value: '48.2k', icon: Zap, color: 'text-amber-400', bgColor: 'bg-amber-500/10', borderColor: 'hover:border-amber-500/30', trend: '+18%' },
-    { label: 'System Health', value: stats?.systemHealth || '99.9%', icon: Cpu, color: 'text-pink-400', bgColor: 'bg-pink-500/10', borderColor: 'hover:border-pink-500/30', trend: 'Stable' }
+    { label: 'Total Users', value: stats?.totalUsers || '0', icon: Users, color: 'text-[#818CF8]', bgColor: 'bg-[#6366F1]/15 border-2 border-[#6366F1]/30', borderColor: 'hover:border-[#6366F1]/60', trend: stats?.growth || '+0%' },
+    { label: 'Active Sessions', value: stats?.activeNow || '0', icon: Activity, color: 'text-emerald-400', bgColor: 'bg-emerald-500/15 border-2 border-emerald-500/30', borderColor: 'hover:border-emerald-500/60', trend: '+5%' },
+    { label: 'API Requests', value: '48.2k', icon: Zap, color: 'text-amber-400', bgColor: 'bg-amber-500/15 border-2 border-amber-500/30', borderColor: 'hover:border-amber-500/60', trend: '+18%' },
+    { label: 'System Health', value: stats?.systemHealth || '99.9%', icon: Cpu, color: 'text-pink-400', bgColor: 'bg-pink-500/15 border-2 border-pink-500/30', borderColor: 'hover:border-pink-500/60', trend: 'Stable' }
   ];
 
   return (
@@ -53,17 +63,18 @@ export default function AdminDashboard() {
           <h2 className="text-2xl md:text-3xl font-black font-clash text-white tracking-tight leading-tight mb-1">
             System Overview
           </h2>
-          <p className="text-sm text-white/40 font-satoshi">
+          <p className="text-sm font-bold text-white/60 font-satoshi">
             Real-time analytics and management across the Kylrix Ecosystem.
           </p>
         </div>
         <button 
           type="button"
-          onClick={fetchStats} 
+          onClick={() => fetchStats(true)}
           disabled={loading}
-          className="p-2.5 rounded-xl bg-white/[0.05] hover:bg-white/10 text-white/60 hover:text-white transition-all duration-200 cursor-pointer disabled:opacity-50 flex items-center justify-center self-start sm:self-auto"
+          className="px-4 py-2.5 rounded-xl bg-[#000000] border-2 border-white/20 hover:border-white/40 text-white font-extrabold text-xs transition-all duration-200 cursor-pointer disabled:opacity-50 flex items-center justify-center gap-2 self-start sm:self-auto shadow-lg"
         >
-          <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+          <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+          <span>Refresh Analytics</span>
         </button>
       </div>
 
@@ -72,25 +83,27 @@ export default function AdminDashboard() {
         {statCards.map((stat) => (
           <div 
             key={stat.label}
-            className={`p-6 rounded-[24px] bg-[#161412] border border-white/5 flex flex-col gap-4 relative overflow-hidden transition-all duration-300 transform hover:-translate-y-1 ${stat.borderColor}`}
+            className={`p-6 rounded-[28px] bg-[#000000] border-2 border-white/20 flex flex-col gap-4 relative overflow-hidden transition-all duration-300 transform hover:-translate-y-1 shadow-2xl ${stat.borderColor}`}
           >
             <div className={`p-3 rounded-2xl ${stat.bgColor} ${stat.color} w-fit`}>
-              <stat.icon size={24} strokeWidth={2.5} />
+              <stat.icon size={22} strokeWidth={2.5} />
             </div>
             <div>
-              <span className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1">
+              <span className="text-[10px] font-black font-mono text-white/50 uppercase tracking-wider block mb-1">
                 {stat.label}
               </span>
               <div className="flex items-baseline gap-3">
-                <span className="text-2xl font-black text-white font-satoshi">
-                  {loading ? (
-                    <div className="animate-pulse w-12 h-6 bg-white/10 rounded" />
+                <span className="text-3xl font-black text-white font-satoshi tracking-tight">
+                  {loading && !stats ? (
+                    <div className="animate-pulse w-16 h-8 bg-white/20 rounded-lg" />
                   ) : (
                     stat.value
                   )}
                 </span>
-                <span className={`text-[10px] font-black font-mono tracking-wider px-2 py-0.5 rounded ${
-                  stat.trend.includes('+') ? 'bg-emerald-500/10 text-emerald-400' : 'text-white/40'
+                <span className={`text-[10px] font-black font-mono tracking-wider px-2 py-0.5 rounded-md border ${
+                  stat.trend.includes('+')
+                    ? 'bg-emerald-500/15 border-emerald-500/30 text-emerald-400'
+                    : 'bg-white/10 border-white/20 text-white/60'
                 }`}>
                   {stat.trend}
                 </span>
@@ -102,21 +115,21 @@ export default function AdminDashboard() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Analytics Chart */}
-        <div className="lg:col-span-2 p-6 md:p-8 rounded-[32px] bg-[#161412] border border-white/5 flex flex-col gap-6 min-h-[400px]">
+        <div className="lg:col-span-2 p-6 md:p-8 rounded-[28px] bg-[#000000] border-2 border-white/20 flex flex-col gap-6 min-h-[400px] shadow-2xl">
           <div className="flex justify-between items-center">
             <h3 className="text-lg font-black font-clash text-white tracking-tight leading-tight">
               Ecosystem Activity
             </h3>
             <button 
               type="button"
-              className="flex items-center gap-1 text-sm font-bold text-[#6366F1] hover:text-[#5254E8] transition-colors cursor-pointer"
+              className="flex items-center gap-1 text-xs font-black text-[#818CF8] hover:text-white transition-colors cursor-pointer uppercase tracking-wider"
             >
               <span>Full Analytics</span>
               <ChevronRight size={16} />
             </button>
           </div>
           
-          <div className="h-[280px] w-full flex items-end justify-between p-4 border border-dashed border-white/5 rounded-2xl bg-[#6366F1]/[0.01] gap-2">
+          <div className="h-[280px] w-full flex items-end justify-between p-4 border-2 border-white/15 rounded-2xl bg-[#000000] gap-2">
             {stats?.analytics ? stats.analytics.map((day: any, i: number) => {
               const max = Math.max(...stats.analytics.map((d: any) => d.users));
               const height = (day.users / max) * 100;
@@ -124,24 +137,24 @@ export default function AdminDashboard() {
                 <div key={i} className="flex flex-col items-center gap-2 flex-1 h-full justify-end">
                   <div className="group relative w-full flex items-end justify-center h-[90%]">
                     <div 
-                      className={`w-full max-w-[24px] rounded-lg transition-all duration-300 hover:bg-[#6366F1] ${
-                        i === 6 ? 'bg-[#6366F1]' : 'bg-[#6366F1]/20'
+                      className={`w-full max-w-[24px] rounded-lg transition-all duration-300 hover:bg-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.5)] ${
+                        i === 6 ? 'bg-[#6366F1]' : 'bg-[#6366F1]/30'
                       }`}
-                      style={{ height: `${Math.max(10, height)}%` }}
+                      style={{ height: `${Math.max(12, height)}%` }}
                     />
-                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block bg-[#1E1C1A] border border-white/10 text-white text-xs px-2.5 py-1.5 rounded-xl whitespace-nowrap shadow-xl z-20 font-semibold">
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block bg-[#000000] border-2 border-white/20 text-white text-xs px-2.5 py-1.5 rounded-xl whitespace-nowrap shadow-2xl z-20 font-black">
                       {day.users} active
                     </div>
                   </div>
-                  <span className="text-[10px] text-white/40 font-bold uppercase tracking-wider block">
+                  <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">
                     {day.name}
                   </span>
                 </div>
               );
             }) : (
               <div className="text-center w-full py-16 flex flex-col items-center gap-3">
-                <TrendingUp size={48} className="text-[#6366F1]/20" strokeWidth={1.5} />
-                <span className="text-sm text-white/20 font-bold font-satoshi">
+                <TrendingUp size={48} className="text-[#6366F1]/40" strokeWidth={2} />
+                <span className="text-xs text-white/40 font-black font-mono">
                   Loading Chart Data...
                 </span>
               </div>
@@ -150,35 +163,35 @@ export default function AdminDashboard() {
         </div>
 
         {/* Recent Signups */}
-        <div className="p-6 md:p-8 rounded-[32px] bg-[#161412] border border-white/5 flex flex-col gap-6 justify-between">
+        <div className="p-6 md:p-8 rounded-[28px] bg-[#000000] border-2 border-white/20 flex flex-col gap-6 justify-between shadow-2xl">
           <div>
             <h3 className="text-lg font-black font-clash text-white tracking-tight leading-tight mb-4">
               Recent Signups
             </h3>
             
-            <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-4">
               {stats?.recentUsers?.length ? stats.recentUsers.slice(0, 4).map((u: any, idx: number) => (
-                <div key={idx} className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-[#6366F1]/10 text-[#6366F1] flex items-center justify-center font-black text-sm flex-shrink-0">
+                <div key={idx} className="flex items-center gap-3 p-3 rounded-2xl bg-[#000000] border-2 border-white/10 hover:border-white/30 transition-all">
+                  <div className="w-10 h-10 rounded-xl bg-[#6366F1] text-white flex items-center justify-center font-black text-sm flex-shrink-0 border-2 border-[#6366F1] shadow-md">
                     {u.name.charAt(0).toUpperCase()}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <h4 className="text-sm font-bold text-white truncate">
+                    <h4 className="text-xs font-black text-white truncate">
                       {u.name}
                     </h4>
-                    <p className="text-xs text-white/40 truncate">
+                    <p className="text-[11px] font-mono text-white/50 truncate">
                       {u.email}
                     </p>
                   </div>
                   <div className="text-right flex-shrink-0">
-                    <span className="text-[10px] text-white/60 block font-medium">
+                    <span className="text-[10px] font-mono font-bold text-white/60 block">
                       {new Date(u.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
                     </span>
-                    <span className="text-[9px] text-[#10B981] font-extrabold uppercase tracking-wider block mt-0.5">NEW</span>
+                    <span className="text-[9px] text-[#10B981] font-black uppercase tracking-wider block mt-0.5">NEW</span>
                   </div>
                 </div>
               )) : (
-                <p className="text-sm text-white/45 text-center py-6">
+                <p className="text-xs font-bold text-white/50 text-center py-6">
                   No recent users to show yet.
                 </p>
               )}
@@ -187,7 +200,7 @@ export default function AdminDashboard() {
 
           <Link
             href="/settings?section=admin-users"
-            className="w-full text-center py-3.5 rounded-xl bg-white/[0.03] border border-white/5 text-white hover:bg-white/[0.06] hover:border-white/10 transition-all font-bold text-xs cursor-pointer block mt-6"
+            className="w-full text-center py-3.5 rounded-xl bg-[#000000] border-2 border-white/20 text-white hover:bg-white/[0.06] hover:border-white/40 transition-all font-black text-xs cursor-pointer block mt-6 shadow-md"
           >
             Manage All Users
           </Link>

--- a/components/admin/EmailOrchestrator.tsx
+++ b/components/admin/EmailOrchestrator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { 
   Send, 
   Layout, 
@@ -12,6 +12,8 @@ import { EMAIL_TEMPLATES, type EmailTemplateId } from '@/lib/email-template-cata
 import { getAdminUsersAction } from '@/lib/actions/billing/admin';
 import { sendAdminEmailsAction } from '@/lib/actions/billing/emails';
 import { useAuth } from '@/context/auth/AuthContext';
+import { LocalEngine } from '@/lib/services/LocalEngine';
+import { getAdminVerifiedUsersCacheKey } from '@/lib/admin/admin-cache';
 
 interface User {
   id: string;
@@ -42,9 +44,9 @@ export default function EmailOrchestrator() {
   const [sending, setSending] = useState(false);
   const [sendResult, setSendResult] = useState<string | null>(null);
   const [userLoadError, setUserLoadError] = useState<string | null>(null);
-  const { getJWT } = useAuth();
+  const { user, getJWT } = useAuth();
 
-  const fetchUsers = async (cursorAfter: string | null = null, append = false) => {
+  const fetchUsers = useCallback(async (cursorAfter: string | null = null, append = false) => {
     const isInitialLoad = !append;
     if (isInitialLoad) {
       setLoadingUsers(true);
@@ -55,23 +57,31 @@ export default function EmailOrchestrator() {
     try {
       setUserLoadError(null);
       const jwt = await getJWT();
-      const data = await getAdminUsersAction({
+      const cacheKey = getAdminVerifiedUsersCacheKey(user?.$id, cursorAfter);
+
+      const fetcher = async () => await getAdminUsersAction({
         verifiedOnly: true,
         limit: 50,
-        cursorAfter}, jwt || undefined);
+        cursorAfter
+      }, jwt || undefined);
+
+      const data = cacheKey
+        ? await LocalEngine.query(cacheKey, fetcher, { ttl: 5 * 60 * 1000 })
+        : await fetcher();
+
       const batch = data.users || [];
       setUsers((prev) => {
         if (!append) {
           return batch;
         }
 
-        const seen = new Set(prev.map((user) => user.id));
+        const seen = new Set(prev.map((u) => u.id));
         const merged = [...prev];
 
-        for (const user of batch) {
-          if (seen.has(user.id)) continue;
-          seen.add(user.id);
-          merged.push(user);
+        for (const u of batch) {
+          if (seen.has(u.id)) continue;
+          seen.add(u.id);
+          merged.push(u);
         }
 
         return merged;
@@ -85,11 +95,11 @@ export default function EmailOrchestrator() {
       setLoadingUsers(false);
       setLoadingMoreUsers(false);
     }
-  };
+  }, [user?.$id, getJWT]);
 
   useEffect(() => {
     void fetchUsers();
-  }, [getJWT]);
+  }, [fetchUsers]);
 
   const filteredUsers = users.filter(u => 
     u.name.toLowerCase().includes(searchTerm.toLowerCase()) || 
@@ -147,17 +157,17 @@ export default function EmailOrchestrator() {
         <h2 className="text-2xl md:text-3xl font-black font-clash text-white tracking-tight leading-tight mb-1">
           Email Center
         </h2>
-        <p className="text-sm text-white/40">
+        <p className="text-sm font-bold text-white/60">
           Design and orchestrate branded ecosystem communications.
         </p>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 font-satoshi text-white">
         {/* Recipient Selection */}
-        <div className="rounded-[24px] bg-[#161412] border border-white/5 flex flex-col overflow-hidden min-h-[500px] lg:h-[680px]">
-          <div className="p-4 border-b border-white/5 flex flex-col gap-3">
-            <h3 className="text-base font-extrabold text-white flex items-center gap-2">
-              <Users size={18} className="text-[#6366F1]" />
+        <div className="rounded-[28px] bg-[#000000] border-2 border-white/20 flex flex-col overflow-hidden min-h-[500px] lg:h-[680px] shadow-2xl">
+          <div className="p-4 border-b-2 border-white/20 flex flex-col gap-3">
+            <h3 className="text-base font-black text-white flex items-center gap-2">
+              <Users size={18} className="text-[#818CF8]" />
               Recipients
             </h3>
             <input 
@@ -165,60 +175,60 @@ export default function EmailOrchestrator() {
               placeholder="Search users..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full bg-white/[0.02] px-4 py-2.5 rounded-xl border border-white/5 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all placeholder:text-white/30"
+              className="w-full bg-[#000000] px-4 py-2.5 rounded-xl border-2 border-white/20 text-white text-sm font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all placeholder:text-white/40 font-mono"
             />
             <button 
               type="button"
               onClick={handleSelectAll}
-              className="text-left text-xs font-bold text-[#6366F1] hover:text-[#5254E8] transition-colors cursor-pointer w-fit"
+              className="text-left text-xs font-black text-[#818CF8] hover:text-white transition-colors cursor-pointer w-fit uppercase tracking-wider font-mono"
             >
               {selectedUsers.length === filteredUsers.length ? 'Deselect All' : `Select All (${filteredUsers.length})`}
             </button>
           </div>
           
-          <div className="flex-grow overflow-y-auto divide-y divide-white/[0.02] max-h-[300px] lg:max-h-none">
+          <div className="flex-grow overflow-y-auto divide-y-2 divide-white/10 max-h-[300px] lg:max-h-none">
             {loadingUsers ? (
               <div className="flex justify-center items-center py-12">
                 <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[#6366F1]" />
               </div>
             ) : filteredUsers.length === 0 ? (
-              <div className="p-8 text-center text-xs text-white/40 font-bold">
+              <div className="p-8 text-center text-xs text-white/50 font-black font-mono">
                 No users found.
               </div>
-            ) : filteredUsers.map((user) => (
+            ) : filteredUsers.map((u) => (
               <div 
-                key={user.id} 
-                onClick={() => handleToggleUser(user.id)}
-                className="flex items-center justify-between p-4 hover:bg-white/[0.01] transition-colors cursor-pointer"
+                key={u.id}
+                onClick={() => handleToggleUser(u.id)}
+                className="flex items-center justify-between p-4 hover:bg-white/[0.04] transition-colors cursor-pointer"
               >
                 <div className="flex items-center gap-3 min-w-0">
-                  <div className="w-8 h-8 rounded-full bg-[#6366F1]/10 text-[#6366F1] flex items-center justify-center font-black text-xs flex-shrink-0">
-                    {user.name.charAt(0).toUpperCase()}
+                  <div className="w-8 h-8 rounded-xl bg-[#6366F1] text-white flex items-center justify-center font-black text-xs shrink-0 border-2 border-[#6366F1] shadow-md">
+                    {u.name.charAt(0).toUpperCase()}
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-sm font-bold text-white truncate">{user.name}</h4>
-                    <p className="text-xs text-white/45 truncate">{user.email}</p>
+                    <h4 className="text-xs font-black text-white truncate">{u.name}</h4>
+                    <p className="text-[11px] font-mono text-white/50 truncate">{u.email}</p>
                   </div>
                 </div>
                 <input 
                   type="checkbox" 
-                  checked={selectedUsers.includes(user.id)}
+                  checked={selectedUsers.includes(u.id)}
                   onChange={() => {}} // toggled by row click
-                  className="rounded border-white/10 bg-[#0A0908] text-[#6366F1] focus:ring-[#6366F1]/20 cursor-pointer h-4 w-4"
+                  className="rounded-md border-2 border-white/20 bg-[#000000] text-[#6366F1] focus:ring-[#6366F1]/30 cursor-pointer h-4 w-4"
                 />
               </div>
             ))}
           </div>
 
-          <div className="p-3 border-t border-white/5">
+          <div className="p-3 border-t-2 border-white/20">
             {userLoadError && (
-              <p className="mb-2 text-red-400 text-xs font-bold">{userLoadError}</p>
+              <p className="mb-2 text-rose-400 text-xs font-bold">{userLoadError}</p>
             )}
             <button
               type="button"
               onClick={handleLoadMoreUsers}
               disabled={!hasMoreUsers || loadingMoreUsers || loadingUsers}
-              className="w-full py-2.5 rounded-xl border border-white/10 text-xs font-extrabold text-white hover:bg-white/5 transition-all cursor-pointer disabled:opacity-30"
+              className="w-full py-2.5 rounded-xl border-2 border-white/20 text-xs font-black text-white hover:bg-white/10 transition-all cursor-pointer disabled:opacity-30"
             >
               {loadingMoreUsers ? (
                 <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current mx-auto" />
@@ -230,24 +240,24 @@ export default function EmailOrchestrator() {
             </button>
           </div>
           
-          <div className="p-3 bg-[#6366F1]/[0.03] border-t border-white/5 text-center">
-            <span className="text-xs font-extrabold text-[#6366F1]">
+          <div className="p-3 bg-[#6366F1]/15 border-t-2 border-white/20 text-center">
+            <span className="text-xs font-black text-white font-mono uppercase tracking-wider">
               {selectedUsers.length} Users Selected
             </span>
           </div>
         </div>
 
         {/* Email Designer */}
-        <div className="lg:col-span-2 p-6 md:p-8 rounded-[24px] bg-[#161412] border border-white/5 flex flex-col gap-6">
+        <div className="lg:col-span-2 p-6 md:p-8 rounded-[28px] bg-[#000000] border-2 border-white/20 flex flex-col gap-6 shadow-2xl">
           <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
-            <h3 className="text-base font-extrabold text-white flex items-center gap-2">
-              <Layout size={18} className="text-[#6366F1]" />
+            <h3 className="text-base font-black text-white flex items-center gap-2">
+              <Layout size={18} className="text-[#818CF8]" />
               Rich Orchestrator
             </h3>
             <div className="flex gap-2">
               <button 
                 type="button"
-                className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-white/10 text-white font-bold text-xs hover:bg-white/5 hover:border-white/20 transition-all cursor-pointer"
+                className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border-2 border-white/20 text-white font-extrabold text-xs hover:bg-white/10 hover:border-white/40 transition-all cursor-pointer"
               >
                 <Eye size={16} />
                 <span>Preview</span>
@@ -256,7 +266,7 @@ export default function EmailOrchestrator() {
                 type="button"
                 onClick={handleSend}
                 disabled={selectedUsers.length === 0 || sending}
-                className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] text-black font-black text-xs transition-all duration-200 cursor-pointer disabled:opacity-40 shadow-[0_8px_30px_rgba(99,102,241,0.2)]"
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] text-white font-black text-xs transition-all duration-200 cursor-pointer disabled:opacity-40 border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)]"
               >
                 {sending ? (
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current" />
@@ -270,64 +280,64 @@ export default function EmailOrchestrator() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Select Template</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Select Template</span>
               <select
                 value={template}
                 onChange={(e) => setTemplate(e.target.value as EmailTemplateId)}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none cursor-pointer transition-all duration-200 animate-fadeIn"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none cursor-pointer transition-all duration-200"
               >
                 {EMAIL_TEMPLATES.map(t => (
-                  <option key={t.id} value={t.id} className="bg-[#161412]">{t.name}</option>
+                  <option key={t.id} value={t.id} className="bg-[#000000]">{t.name}</option>
                 ))}
               </select>
             </div>
 
             <div className="space-y-1.5">
-              <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Logo Variation</span>
+              <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Logo Variation</span>
               <select
                 value={logoVar}
                 onChange={(e) => setLogoVar(e.target.value)}
-                className="w-full bg-[#0A0908] px-4 py-3 rounded-xl border border-white/10 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none cursor-pointer transition-all duration-200"
+                className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none cursor-pointer transition-all duration-200"
               >
                 {logoVariations.map(l => (
-                  <option key={l.id} value={l.id} className="bg-[#161412]">{l.name}</option>
+                  <option key={l.id} value={l.id} className="bg-[#000000]">{l.name}</option>
                 ))}
               </select>
             </div>
           </div>
 
           <div className="space-y-1.5">
-            <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Email Subject</span>
+            <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Email Subject</span>
             <input 
               type="text"
               placeholder="Enter custom subject or use template default"
               value={customSubject}
               onChange={(e) => setCustomSubject(e.target.value)}
-              className="w-full bg-white/[0.02] px-4 py-3 rounded-xl border border-white/5 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all placeholder:text-white/30"
+              className="w-full bg-[#000000] px-4 py-3 rounded-xl border-2 border-white/20 text-white text-sm font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all placeholder:text-white/40 font-mono text-xs"
             />
           </div>
 
           <div className="space-y-1.5">
-            <span className="text-[10px] text-white/40 font-bold font-mono uppercase tracking-wider block">Email Content</span>
+            <span className="text-[10px] text-white/50 font-black font-mono uppercase tracking-wider block">Email Content</span>
             <textarea 
               rows={8}
               placeholder="The template will be used, but you can inject custom HTML or text here..."
               value={customBody}
               onChange={(e) => setCustomBody(e.target.value)}
-              className="w-full bg-white/[0.02] px-4 py-3.5 rounded-xl border border-white/5 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all placeholder:text-white/30 font-mono text-xs leading-relaxed"
+              className="w-full bg-[#000000] px-4 py-3.5 rounded-xl border-2 border-white/20 text-white text-xs font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all placeholder:text-white/40 font-mono leading-relaxed"
             />
           </div>
 
-          <div className="p-4 rounded-2xl bg-emerald-500/[0.04] border border-emerald-500/10 flex gap-3 items-center">
+          <div className="p-4 rounded-2xl bg-emerald-500/10 border-2 border-emerald-500/30 flex gap-3 items-center">
             <CheckCircle2 className="text-[#10B981] w-5 h-5 flex-shrink-0" />
-            <p className="text-xs text-white/60 leading-normal">
+            <p className="text-xs font-bold text-white/80 leading-normal">
               This orchestration will be delivered with <strong>E2EE Signing</strong> and Kylrix branded metadata.
             </p>
           </div>
 
           {sendResult && (
-            <div className="p-4 rounded-2xl bg-[#6366F1]/10 border border-[#6366F1]/20">
-              <p className="text-xs font-bold text-white leading-normal">{sendResult}</p>
+            <div className="p-4 rounded-2xl bg-[#6366F1]/20 border-2 border-[#6366F1]/40">
+              <p className="text-xs font-black text-white leading-normal">{sendResult}</p>
             </div>
           )}
         </div>

--- a/components/admin/UsersManagement.tsx
+++ b/components/admin/UsersManagement.tsx
@@ -15,6 +15,8 @@ import {
 import AdminLayout from '@/components/admin/components/AdminLayout';
 import { getAdminUsersAction } from '@/lib/actions/billing/admin';
 import { useAuth } from '@/context/auth/AuthContext';
+import { LocalEngine } from '@/lib/services/LocalEngine';
+import { getAdminUsersCacheKey } from '@/lib/admin/admin-cache';
 
 interface User {
   id: string;
@@ -32,29 +34,39 @@ export default function UsersManagement() {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { getJWT } = useAuth();
+  const { user, getJWT } = useAuth();
 
-  const fetchUsers = useCallback(async () => {
+  const fetchUsers = useCallback(async (force = false) => {
+    const cacheKey = getAdminUsersCacheKey(user?.$id, searchTerm);
+    if (!cacheKey) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
       const jwt = await getJWT();
-      const data = await getAdminUsersAction({
-        search: searchTerm,
-        verifiedOnly: false,
-        limit: 100}, jwt || undefined);
-      setUsers(data.users);
+      const data = await LocalEngine.query(
+        cacheKey,
+        async () => await getAdminUsersAction({
+          search: searchTerm,
+          verifiedOnly: false,
+          limit: 100
+        }, jwt || undefined),
+        { ttl: 3 * 60 * 1000, force }
+      );
+      setUsers(data.users || []);
     } catch (err: any) {
-      setError(err.message);
+      setError(err.message || 'Failed to fetch users');
     } finally {
       setLoading(false);
     }
-  }, [searchTerm, getJWT]);
+  }, [user?.$id, searchTerm, getJWT]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
       fetchUsers();
-    }, 500);
+    }, 400);
     return () => clearTimeout(timer);
   }, [fetchUsers]);
 
@@ -65,22 +77,22 @@ export default function UsersManagement() {
           <h2 className="text-2xl md:text-3xl font-black font-clash text-white tracking-tight leading-tight mb-1">
             User Directory
           </h2>
-          <p className="text-sm text-white/40 font-satoshi">
+          <p className="text-sm font-bold text-white/60 font-satoshi">
             Manage ecosystem members, permissions, and status.
           </p>
         </div>
         <div className="flex items-center gap-3">
           <button 
             type="button"
-            onClick={() => fetchUsers()} 
+            onClick={() => fetchUsers(true)}
             disabled={loading}
-            className="p-2.5 rounded-xl bg-white/[0.05] hover:bg-white/10 text-white/60 hover:text-white transition-all duration-200 cursor-pointer disabled:opacity-50 flex items-center justify-center"
+            className="p-3 rounded-xl bg-[#000000] border-2 border-white/20 hover:border-white/40 text-white/70 hover:text-white transition-all duration-200 cursor-pointer disabled:opacity-50 flex items-center justify-center shadow-lg"
           >
             <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
           </button>
           <button 
             type="button"
-            className="flex items-center gap-2 px-5 py-3 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] text-black font-black text-xs transition-all duration-200 cursor-pointer shadow-[0_8px_30px_rgba(99,102,241,0.2)]"
+            className="flex items-center gap-2 px-5 py-3 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] text-white font-black text-xs transition-all duration-200 cursor-pointer border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)]"
           >
             <UserPlus size={18} />
             <span>Add Member</span>
@@ -89,32 +101,32 @@ export default function UsersManagement() {
       </div>
 
       {/* Filter Bar */}
-      <div className="p-4 rounded-[20px] bg-[#161412] border border-white/5 mb-6">
+      <div className="p-4 rounded-[22px] bg-[#000000] border-2 border-white/20 mb-6 shadow-2xl">
         <div className="relative w-full">
-          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4.5 h-4.5 text-white/40" />
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4.5 h-4.5 text-white/50" />
           <input 
             type="text"
             placeholder="Search users by name, email, or ID..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full bg-white/[0.02] pl-12 pr-4 py-3.5 rounded-xl border border-white/5 text-white text-sm font-semibold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/10 focus:outline-none transition-all duration-200 placeholder:text-white/30"
+            className="w-full bg-[#000000] pl-12 pr-4 py-3.5 rounded-xl border-2 border-white/20 text-white text-sm font-bold focus:border-[#6366F1] focus:ring-4 focus:ring-[#6366F1]/20 focus:outline-none transition-all duration-200 placeholder:text-white/40 font-mono"
           />
         </div>
       </div>
 
       {/* Users Table Container */}
-      <div className="rounded-[28px] bg-[#161412] border border-white/5 overflow-hidden min-h-[200px] flex flex-col">
+      <div className="rounded-[28px] bg-[#000000] border-2 border-white/20 overflow-hidden min-h-[200px] flex flex-col shadow-2xl">
         {loading && users.length === 0 ? (
           <div className="flex justify-center items-center py-16">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#6366F1]" />
           </div>
         ) : error ? (
           <div className="p-8 text-center flex flex-col items-center gap-3">
-            <span className="text-red-400 font-bold text-sm">{error}</span>
+            <span className="text-rose-400 font-extrabold text-sm">{error}</span>
             <button 
               type="button"
-              onClick={() => fetchUsers()} 
-              className="px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-xs font-extrabold cursor-pointer"
+              onClick={() => fetchUsers(true)}
+              className="px-4 py-2 rounded-xl bg-[#000000] border-2 border-white/20 hover:border-white/40 text-xs font-black text-white cursor-pointer"
             >
               Retry
             </button>
@@ -123,49 +135,49 @@ export default function UsersManagement() {
           <div className="overflow-x-auto font-satoshi">
             <table className="w-full text-left border-collapse">
               <thead>
-                <tr className="bg-white/[0.02] border-b border-white/5">
-                  <th className="px-6 py-4 text-[10px] font-black text-white/40 uppercase tracking-wider">Member</th>
-                  <th className="px-6 py-4 text-[10px] font-black text-white/40 uppercase tracking-wider">Status</th>
-                  <th className="px-6 py-4 text-[10px] font-black text-white/40 uppercase tracking-wider">Role</th>
-                  <th className="px-6 py-4 text-[10px] font-black text-white/40 uppercase tracking-wider">Joined</th>
-                  <th className="px-6 py-4 text-[10px] font-black text-white/40 uppercase tracking-wider text-right">Actions</th>
+                <tr className="bg-[#000000] border-b-2 border-white/20">
+                  <th className="px-6 py-4 text-[10px] font-black text-white/60 uppercase tracking-wider font-mono">Member</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-white/60 uppercase tracking-wider font-mono">Status</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-white/60 uppercase tracking-wider font-mono">Role</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-white/60 uppercase tracking-wider font-mono">Joined</th>
+                  <th className="px-6 py-4 text-[10px] font-black text-white/60 uppercase tracking-wider text-right font-mono">Actions</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-white/[0.03]">
-                {users.map((user) => (
-                  <tr key={user.id} className="hover:bg-white/[0.01] transition-colors">
+              <tbody className="divide-y-2 divide-white/10">
+                {users.map((u) => (
+                  <tr key={u.id} className="hover:bg-white/[0.04] transition-colors">
                     <td className="px-6 py-4.5">
                       <div className="flex items-center gap-3">
-                        <div className="w-9 h-9 rounded-full bg-[#6366F1]/10 text-[#6366F1] flex items-center justify-center font-black text-sm">
-                          {user.name.charAt(0).toUpperCase()}
+                        <div className="w-10 h-10 rounded-xl bg-[#6366F1] text-white border-2 border-[#6366F1] flex items-center justify-center font-black text-sm shrink-0 shadow-md">
+                          {u.name.charAt(0).toUpperCase()}
                         </div>
                         <div className="min-w-0">
-                          <h4 className="text-sm font-bold text-white truncate">{user.name}</h4>
-                          <p className="text-xs text-white/40 truncate">{user.email}</p>
+                          <h4 className="text-xs font-black text-white truncate">{u.name}</h4>
+                          <p className="text-[11px] font-mono text-white/50 truncate">{u.email}</p>
                         </div>
                       </div>
                     </td>
                     <td className="px-6 py-4.5">
-                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded text-[10px] font-black uppercase tracking-wider border ${
-                        user.status === 'active' 
-                          ? 'bg-emerald-500/10 border-emerald-500/20 text-emerald-400' 
-                          : 'bg-white/5 border-white/10 text-white/50'
+                      <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-[10px] font-black font-mono uppercase tracking-wider border ${
+                        u.status === 'active'
+                          ? 'bg-emerald-500/15 border-emerald-500/30 text-emerald-400'
+                          : 'bg-white/10 border-white/20 text-white/60'
                       }`}>
-                        {user.status}
+                        {u.status}
                       </span>
                     </td>
                     <td className="px-6 py-4.5">
-                      <div className="flex items-center gap-1.5 text-sm font-semibold text-white/90">
-                        {user.role === 'admin' ? (
-                          <Shield size={14} className="text-[#6366F1]" />
+                      <div className="flex items-center gap-1.5 text-xs font-black text-white">
+                        {u.role === 'admin' ? (
+                          <Shield size={14} className="text-[#818CF8]" />
                         ) : (
-                          <Activity size={14} className="text-white/20" />
+                          <Activity size={14} className="text-white/40" />
                         )}
-                        <span className="capitalize">{user.role}</span>
+                        <span className="capitalize">{u.role}</span>
                       </div>
                     </td>
-                    <td className="px-6 py-4.5 text-sm text-white/60">
-                      {user.joinDate}
+                    <td className="px-6 py-4.5 text-xs font-mono font-bold text-white/60">
+                      {u.joinDate}
                     </td>
                     <td className="px-6 py-4.5 align-middle">
                       <div className="flex justify-end items-center gap-2">
@@ -173,11 +185,11 @@ export default function UsersManagement() {
                         <div className="group relative">
                           <button 
                             type="button"
-                            className="p-1.5 rounded-lg text-white/40 hover:text-[#6366F1] hover:bg-[#6366F1]/10 transition-all cursor-pointer"
+                            className="p-2 rounded-xl border-2 border-white/10 hover:border-white/30 text-white/60 hover:text-white bg-[#000000] transition-all cursor-pointer"
                           >
                             <Mail size={16} />
                           </button>
-                          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover:block bg-[#1E1C1A] border border-white/10 text-white text-[10px] px-2 py-1 rounded whitespace-nowrap shadow-xl z-20 font-bold uppercase tracking-wider">
+                          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover:block bg-[#000000] border-2 border-white/20 text-white text-[10px] px-2.5 py-1 rounded-lg whitespace-nowrap shadow-2xl z-20 font-black uppercase tracking-wider">
                             Send Email
                           </div>
                         </div>
@@ -186,20 +198,22 @@ export default function UsersManagement() {
                         <div className="group relative">
                           <button 
                             type="button"
-                            className={`p-1.5 rounded-lg text-white/40 hover:bg-white/5 transition-all cursor-pointer ${
-                              user.status === 'active' ? 'hover:text-red-400 hover:bg-red-500/10' : 'hover:text-emerald-400 hover:bg-emerald-500/10'
+                            className={`p-2 rounded-xl border-2 transition-all cursor-pointer bg-[#000000] ${
+                              u.status === 'active'
+                                ? 'border-white/10 hover:border-rose-500/40 text-white/60 hover:text-rose-400'
+                                : 'border-white/10 hover:border-emerald-500/40 text-white/60 hover:text-emerald-400'
                             }`}
                           >
-                            {user.status === 'active' ? <Trash2 size={16} /> : <CheckCircle2 size={16} />}
+                            {u.status === 'active' ? <Trash2 size={16} /> : <CheckCircle2 size={16} />}
                           </button>
-                          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover:block bg-[#1E1C1A] border border-white/10 text-white text-[10px] px-2 py-1 rounded whitespace-nowrap shadow-xl z-20 font-bold uppercase tracking-wider">
-                            {user.status === 'active' ? 'Suspend User' : 'Activate User'}
+                          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover:block bg-[#000000] border-2 border-white/20 text-white text-[10px] px-2.5 py-1 rounded-lg whitespace-nowrap shadow-2xl z-20 font-black uppercase tracking-wider">
+                            {u.status === 'active' ? 'Suspend User' : 'Activate User'}
                           </div>
                         </div>
 
                         <button 
                           type="button"
-                          className="p-1.5 rounded-lg text-white/40 hover:text-white transition-all cursor-pointer"
+                          className="p-2 rounded-xl border-2 border-white/10 hover:border-white/30 text-white/60 hover:text-white bg-[#000000] transition-all cursor-pointer"
                         >
                           <MoreVertical size={16} />
                         </button>
@@ -209,7 +223,7 @@ export default function UsersManagement() {
                 ))}
                 {!loading && users.length === 0 && (
                   <tr>
-                    <td colSpan={5} className="px-6 py-12 text-center text-sm text-white/40 font-bold">
+                    <td colSpan={5} className="px-6 py-12 text-center text-xs text-white/50 font-black font-mono">
                       No users found matching your search.
                     </td>
                   </tr>

--- a/components/admin/admin-cache.test.ts
+++ b/components/admin/admin-cache.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getAdminStatsCacheKey,
+  getAdminUsersCacheKey,
+  getAdminVerifiedUsersCacheKey,
+  getAdminCouponsCacheKey,
+} from '@/lib/admin/admin-cache';
+
+describe('Admin LocalEngine Account-Scoped Caching Keys', () => {
+  it('should return null when user ID is missing or empty', () => {
+    expect(getAdminStatsCacheKey(null)).toBeNull();
+    expect(getAdminStatsCacheKey(undefined)).toBeNull();
+    expect(getAdminStatsCacheKey('')).toBeNull();
+
+    expect(getAdminUsersCacheKey(null, 'test')).toBeNull();
+    expect(getAdminVerifiedUsersCacheKey(undefined, 'cursor1')).toBeNull();
+    expect(getAdminCouponsCacheKey(null)).toBeNull();
+  });
+
+  it('should generate account-scoped stats cache key correctly', () => {
+    const userAKey = getAdminStatsCacheKey('user_admin_123');
+    const userBKey = getAdminStatsCacheKey('user_admin_456');
+
+    expect(userAKey).toBe('admin_stats:user_admin_123');
+    expect(userBKey).toBe('admin_stats:user_admin_456');
+    expect(userAKey).not.toBe(userBKey);
+  });
+
+  it('should generate account-scoped users search cache key correctly', () => {
+    const keyA = getAdminUsersCacheKey('user_123', '  John Doe ');
+    const keyB = getAdminUsersCacheKey('user_456', 'John Doe');
+
+    expect(keyA).toBe('admin_users:user_123:john doe');
+    expect(keyB).toBe('admin_users:user_456:john doe');
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it('should generate account-scoped verified users cache key correctly', () => {
+    const keyDefault = getAdminVerifiedUsersCacheKey('user_123', null);
+    const keyWithCursor = getAdminVerifiedUsersCacheKey('user_123', 'cursor_abc');
+
+    expect(keyDefault).toBe('admin_verified_users:user_123:root');
+    expect(keyWithCursor).toBe('admin_verified_users:user_123:cursor_abc');
+  });
+
+  it('should generate account-scoped coupons cache key correctly', () => {
+    const keyA = getAdminCouponsCacheKey('user_123');
+    const keyB = getAdminCouponsCacheKey('user_456');
+
+    expect(keyA).toBe('admin_coupons:user_123');
+    expect(keyB).toBe('admin_coupons:user_456');
+    expect(keyA).not.toBe(keyB);
+  });
+});

--- a/components/admin/components/AdminLayout.tsx
+++ b/components/admin/components/AdminLayout.tsx
@@ -23,7 +23,7 @@ const menuItems = [
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
     <Suspense fallback={
-      <div className="flex justify-center items-center min-h-screen bg-[#0A0908]">
+      <div className="flex justify-center items-center min-h-screen bg-[#000000]">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#6366F1]" />
       </div>
     }>
@@ -48,9 +48,9 @@ function AdminLayoutContent({ children }: { children: React.ReactNode }) {
 
   return (
     <AdminGuard>
-      <div className="flex min-h-screen bg-[#0A0908] text-white font-satoshi">
+      <div className="flex min-h-screen bg-[#000000] text-white font-satoshi">
         {/* Desktop Sidebar */}
-        <aside className="hidden md:flex flex-col w-[280px] bg-[#161412] border-r border-white/5 p-6 flex-shrink-0">
+        <aside className="hidden md:flex flex-col w-[280px] bg-[#000000] border-r-2 border-white/20 p-6 flex-shrink-0">
           <div className="flex items-center gap-3 mb-8">
             <Logo app="accounts" variant="icon" size={32} />
             <div>
@@ -63,7 +63,7 @@ function AdminLayoutContent({ children }: { children: React.ReactNode }) {
             </div>
           </div>
 
-          <nav className="flex-1 space-y-1">
+          <nav className="flex-1 space-y-1.5">
             {menuItems.map((item) => {
               const isActive = pathname === item.href;
               const Icon = item.icon;
@@ -72,32 +72,32 @@ function AdminLayoutContent({ children }: { children: React.ReactNode }) {
                   key={item.label}
                   type="button"
                   onClick={() => router.push(item.href)}
-                  className={`flex items-center justify-between w-full px-4 py-3 rounded-xl text-sm font-bold transition-all duration-200 cursor-pointer ${
+                  className={`flex items-center justify-between w-full px-4 py-3 rounded-xl text-xs font-extrabold transition-all duration-200 cursor-pointer ${
                     isActive
-                      ? 'bg-[#6366F1]/10 text-white border border-[#6366F1]/20'
-                      : 'text-white/50 hover:bg-white/[0.02] hover:text-white border border-transparent'
+                      ? 'bg-[#6366F1] text-white border-2 border-[#6366F1] shadow-[0_0_12px_rgba(99,102,241,0.35)]'
+                      : 'text-white/70 hover:bg-white/[0.06] hover:text-white border-2 border-transparent hover:border-white/20'
                   }`}
                 >
                   <div className="flex items-center gap-3">
-                    <Icon className={`w-5 h-5 ${isActive ? 'text-[#6366F1]' : 'text-white/40'}`} strokeWidth={isActive ? 2.5 : 2} />
+                    <Icon className={`w-5 h-5 ${isActive ? 'text-white' : 'text-white/50'}`} strokeWidth={2.5} />
                     <span>{item.label}</span>
                   </div>
-                  {isActive && <ChevronRight className="w-3.5 h-3.5 text-white/60" />}
+                  {isActive && <ChevronRight className="w-4 h-4 text-white" />}
                 </button>
               );
             })}
           </nav>
 
-          <div className="mt-auto pt-6 border-t border-white/5">
-            <div className="flex items-center gap-3 p-4 rounded-2xl bg-[#6366F1]/[0.03] border border-white/[0.03]">
-              <div className="p-2 rounded-xl bg-[#6366F1]/10 text-[#6366F1]">
+          <div className="mt-auto pt-6 border-t-2 border-white/10">
+            <div className="flex items-center gap-3 p-4 rounded-2xl bg-[#000000] border-2 border-white/20 shadow-lg">
+              <div className="p-2 rounded-xl bg-[#6366F1]/20 border-2 border-[#6366F1]/40 text-[#6366F1]">
                 <ShieldCheck className="w-5 h-5" />
               </div>
               <div>
-                <h4 className="font-bold text-xs text-white">
+                <h4 className="font-black text-xs text-white">
                   Secure Access
                 </h4>
-                <p className="text-[10px] text-white/40">
+                <p className="text-[10px] font-bold text-white/50">
                   Admin Privileges Active
                 </p>
               </div>
@@ -112,7 +112,7 @@ function AdminLayoutContent({ children }: { children: React.ReactNode }) {
       </div>
 
       {/* Mobile Bottom Navigation */}
-      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 h-[72px] bg-[#161412] border-t border-white/5 flex items-center justify-around px-4 shadow-[0_-12px_36px_rgba(0,0,0,0.34)]">
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 h-[72px] bg-[#000000] border-t-2 border-white/20 flex items-center justify-around px-4 shadow-2xl">
         {menuItems.map((item) => {
           const isActive = pathname === item.href;
           const Icon = item.icon;

--- a/lib/admin/admin-cache.ts
+++ b/lib/admin/admin-cache.ts
@@ -1,0 +1,24 @@
+/**
+ * Account-scoped cache key generators for Admin LocalEngine integration.
+ * Guarantees that local engine admin data is strictly partitioned by user account ID.
+ */
+
+export function getAdminStatsCacheKey(userId?: string | null): string | null {
+  if (!userId) return null;
+  return `admin_stats:${userId}`;
+}
+
+export function getAdminUsersCacheKey(userId?: string | null, search = ''): string | null {
+  if (!userId) return null;
+  return `admin_users:${userId}:${search.trim().toLowerCase()}`;
+}
+
+export function getAdminVerifiedUsersCacheKey(userId?: string | null, cursorAfter?: string | null): string | null {
+  if (!userId) return null;
+  return `admin_verified_users:${userId}:${cursorAfter || 'root'}`;
+}
+
+export function getAdminCouponsCacheKey(userId?: string | null): string | null {
+  if (!userId) return null;
+  return `admin_coupons:${userId}`;
+}


### PR DESCRIPTION
- Restyled Settings > Admin sub-tabs and admin views (`AdminDashboard`, `UsersManagement`, `EmailOrchestrator`, `AdminCoupons`, `AdminLayout`) with high-contrast pitch-black components (`#000000`, `border-2 border-white/20`, crisp monospaced details, glowing action states) matching the Settings design system.
- Created `lib/admin/admin-cache.ts` with account-scoped cache key generators (`getAdminStatsCacheKey`, `getAdminUsersCacheKey`, `getAdminVerifiedUsersCacheKey`, `getAdminCouponsCacheKey`).
- Backed all admin data reads with `LocalEngine.query`, strictly scoping cache keys to the active user account ID (`user.$id`), ensuring fast local rendering with zero DB overhead while guaranteeing multi-account isolation on shared client devices.
- Added unit tests in `components/admin/admin-cache.test.ts` verifying account-scoped key generation and cache isolation.

---
*PR created automatically by Jules for task [474110866386307978](https://jules.google.com/task/474110866386307978) started by @nathfavour*