### PR TITLE
test: add test coverage down to the last mile across SDK and utils

### DIFF
--- a/sdk/api/index.test.ts
+++ b/sdk/api/index.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildApiPath, createApiModulePaths } from './index';
+import { buildApiPath, apiV1Path, createApiModulePaths } from './index';
 import { API_V1_SEGMENTS, isWorkspaceSegment, workspaceIdParam } from './routes';
 
 describe('api helpers', () => {
   it('builds clean api paths', () => {
     expect(buildApiPath('/api/', '/connect/', '/messages/')).toBe('/api/connect/messages');
+    expect(apiV1Path('notes', '123')).toBe('/api/v1/notes/123');
   });
 
   it('creates v1 resource namespaces by default', () => {
@@ -12,13 +13,31 @@ describe('api helpers', () => {
     expect(paths.me).toBe('/api/v1/me');
     expect(paths.mcp).toBe('/api/v1/mcp');
     expect(paths.goals).toBe('/api/v1/goals');
+    expect(paths.notes).toBe('/api/v1/notes');
+    expect(paths.workspaces).toBe('/api/v1/workspaces');
+    expect(paths.projects).toBe('/api/v1/projects');
+    expect(paths.events).toBe('/api/v1/events');
+    expect(paths.forms).toBe('/api/v1/forms');
+    expect(paths.tags).toBe('/api/v1/tags');
+    expect(paths.trash).toBe('/api/v1/trash');
+    expect(paths.moments).toBe('/api/v1/moments');
+    expect(paths.chats).toBe('/api/v1/chats');
+    expect(paths.agents).toBe('/api/v1/agents');
+    expect(paths.threads).toBe('/api/v1/threads');
+    expect(paths.vault).toBe('/api/v1/vault');
+    expect(paths.pats).toBe('/api/v1/pats');
     expect(paths.flows.root).toBe('/api/v1/flows');
     expect(paths.flows.installations).toBe('/api/v1/flows/installations');
     expect(paths.flows.flowInstallations('flow1')).toBe('/api/v1/flows/flow1/installations');
     expect(paths.token.root).toBe('/api/v1/token');
     expect(paths.token.scopes).toBe('/api/v1/token/scopes');
     expect(paths.connect.messages).toBe('/api/v1/connect/messages');
+    expect(paths.connect.reactions).toBe('/api/v1/connect/message-reactions');
+    expect(paths.connect.joinRequests).toBe('/api/v1/connect/join-requests');
+    expect(paths.connect.repair).toBe('/api/v1/connect/repair');
+    expect(paths.forward.conversations).toBe('/api/v1/forward/conversations');
     expect(paths.forward.send).toBe('/api/v1/forward/send');
+    expect(paths.forward.targets).toBe('/api/v1/forward/targets');
   });
 
   it('allows legacy base override', () => {
@@ -35,5 +54,6 @@ describe('api helpers', () => {
     const params = new URLSearchParams('workspaceId=ws1');
     expect(workspaceIdParam(params)).toBe('ws1');
     expect(workspaceIdParam(new URLSearchParams('projectId=p1'))).toBe('p1');
+    expect(workspaceIdParam(new URLSearchParams())).toBeNull();
   });
 });

--- a/sdk/appwrite/index.test.ts
+++ b/sdk/appwrite/index.test.ts
@@ -1,15 +1,40 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createProfilePreviewManager } from './index';
 
 describe('appwrite helpers', () => {
-  it('caches profile previews after the first fetch', async () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('caches profile previews after the first fetch and supports sessionStorage', async () => {
+    sessionStorage.setItem('kylrix_avatar_cache', JSON.stringify({ 'file-pre': 'prefilled' }));
+
     const fetcher = vi.fn(async (fileId: string) => `preview:${fileId}`);
     const manager = createProfilePreviewManager(fetcher);
+
+    expect(manager.getCachedProfilePreview('file-pre')).toBe('prefilled');
 
     await expect(manager.fetchProfilePreview('file-1')).resolves.toBe('preview:file-1');
     await expect(manager.fetchProfilePreview('file-1')).resolves.toBe('preview:file-1');
 
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(manager.getCachedProfilePreview('file-1')).toBe('preview:file-1');
+
+    manager.clearProfilePreviewCache();
+    expect(manager.getCachedProfilePreview('file-1')).toBeUndefined();
+  });
+
+  it('handles empty fileId and fetcher errors gracefully', async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error('Network error');
+    });
+    const manager = createProfilePreviewManager(fetcher);
+
+    await expect(manager.fetchProfilePreview('')).resolves.toBeNull();
+    expect(manager.getCachedProfilePreview('')).toBeNull();
+    expect(manager.getCachedProfilePreview(null)).toBeNull();
+
+    await expect(manager.fetchProfilePreview('file-err')).resolves.toBeNull();
+    expect(manager.getCachedProfilePreview('file-err')).toBeNull();
   });
 });

--- a/sdk/contracts/index.test.ts
+++ b/sdk/contracts/index.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import { mcpListResult } from './common';
+import { shapeAgentSessionListItem, shapeAgentSessionDetail } from './agents';
+import { shapeVaultItem, shapeTotpSecret } from './vault';
+import { shapeGoal, buildGoalCreateRow, buildGoalUpdatePatch, resolveWorkspaceId } from './goals';
+import { shapeWorkspace, shapeWorkspaceCollaborator } from './workspaces';
+import { shapeWorkspaceProject } from './projects';
+import { shapeNote } from './notes';
+import { shapeThread, shapeThreadMessage, shapeLegacyThreadComment } from './threads';
+import { shapeProfile, shapeTokenMe, shapeTokenScopeCatalog, shapeTokenRefreshResult } from './auth';
+import { shapeChatListItem, shapeChatDetail, shapeChatMessage } from './chats';
+import { shapeEventListItem, shapeEventDetail } from './events';
+import { shapeFlowListItem, shapeFlowInstallListItem, resolveFlowCreateFields } from './flows';
+import { shapeFormListItem, shapeFormDetail } from './forms';
+import { shapeMoment, shapeMomentCommentEcosystem, shapeMomentCommentNostr, shapeMomentCommentCreated } from './moments';
+import { shapeTag } from './tags';
+import { shapeTrashNoteItem, shapeTrashGoalItem, shapeTrashVaultItem, shapeTrashEventItem, shapeTrashFormItem } from './trash';
+
+describe('sdk/contracts helpers', () => {
+  it('common helpers', () => {
+    const listRes = mcpListResult(['a', 'b']);
+    expect(listRes).toEqual({ items: ['a', 'b'] });
+  });
+
+  it('agents contract helpers', () => {
+    const item = shapeAgentSessionListItem({ $id: 's1', context: 'Goal', status: 'active' });
+    expect(item.id).toBe('s1');
+    expect(item.title).toBe('Goal');
+
+    const detail = shapeAgentSessionDetail({
+      $id: 's1',
+      chatHistory: JSON.stringify([{ role: 'user', content: 'Hi' }]),
+    });
+    expect(detail.id).toBe('s1');
+    expect(detail.history.length).toBe(1);
+
+    const badDetail = shapeAgentSessionDetail({ $id: 's2', chatHistory: 'invalid-json{' });
+    expect(badDetail.history).toEqual([]);
+  });
+
+  it('vault contract helpers', () => {
+    const vaultItem = shapeVaultItem(
+      { $id: 'v1', name: 'My Secret', password: 'secretpassword' },
+      { unsealed: { name: 'My Secret', password: 'unsealedpassword' }, hasMek: true }
+    );
+    expect(vaultItem.id).toBe('v1');
+    expect(vaultItem.secret).toBe('unsealedpassword');
+
+    const unsealedVaultItem = shapeVaultItem(
+      { $id: 'v2', name: 'EncryptedName', username: 'EncryptedUser' },
+      { looksEncrypted: () => true, hasMek: false }
+    );
+    expect(unsealedVaultItem.name).toBe('Protected Secret');
+    expect(unsealedVaultItem.username).toBeNull();
+
+    const totpItem = shapeTotpSecret(
+      { $id: 't1', issuer: 'GitHub', secretKey: 'JBSWY3DPEHPK3PXP' },
+      { unsealed: { issuer: 'GitHub', secretKey: 'JBSWY3DPEHPK3PXP' }, hasMek: true }
+    );
+    expect(totpItem.id).toBe('t1');
+    expect(totpItem.issuer).toBe('GitHub');
+
+    const unsealedTotp = shapeTotpSecret(
+      { $id: 't2', issuer: 'EncryptedIssuer' },
+      { looksEncrypted: () => true, hasMek: false }
+    );
+    expect(unsealedTotp.issuer).toBe('Encrypted Code');
+  });
+
+  it('goals contract helpers', () => {
+    const goal = shapeGoal({ $id: 'g1', title: 'Goal 1', isPublic: true, isGuest: false });
+    expect(goal.id).toBe('g1');
+    expect(goal.title).toBe('Goal 1');
+
+    const row = buildGoalCreateRow('user-1', {
+      title: ' New Goal ',
+      summary: 'Goal Summary',
+      status: 'todo',
+      priority: 'high',
+      isPublic: true,
+      isGuest: true,
+      tags: ['tag1'],
+      isPinned: true,
+      isAgentic: true,
+    });
+    expect(row.title).toBe('New Goal');
+    expect(row.description).toBe('Goal Summary');
+    expect(row.priority).toBe('high');
+
+    const patch = buildGoalUpdatePatch({
+      title: 'Updated Goal',
+      status: 'done',
+      description: 'Desc',
+      summary: 'Sum',
+      priority: 'urgent',
+      dueDate: '2025-12-31',
+      isPublic: false,
+      isGuest: false,
+      isPinned: false,
+      isAgentic: false,
+      tags: ['t2'],
+    });
+    expect(patch.title).toBe('Updated Goal');
+    expect(patch.status).toBe('done');
+    expect(patch.completedAt).toBeDefined();
+
+    const patchNotDone = buildGoalUpdatePatch({
+      status: 'in_progress',
+      summary: 'Summary update',
+    });
+    expect(patchNotDone.completedAt).toBeNull();
+
+    expect(resolveWorkspaceId({ workspaceId: 'ws-100' })).toBe('ws-100');
+    expect(resolveWorkspaceId({ projectId: 'p-200' })).toBe('p-200');
+    expect(resolveWorkspaceId({})).toBeNull();
+  });
+
+  it('workspaces & projects contract helpers', () => {
+    const ws = shapeWorkspace({ $id: 'w1', name: 'Workspace One' }, { isShared: true, role: 'admin' });
+    expect(ws.id).toBe('w1');
+    expect(ws.title).toBe('Workspace One');
+    expect(ws.isShared).toBe(true);
+
+    const collab = shapeWorkspaceCollaborator({ $id: 'c1', userId: 'u1', permission: 'admin' });
+    expect(collab.id).toBe('c1');
+    expect(collab.role).toBe('admin');
+
+    const proj = shapeWorkspaceProject({ $id: 'p1', name: 'Project One' }, 'w1');
+    expect(proj.id).toBe('p1');
+    expect(proj.parentWorkspaceId).toBe('w1');
+  });
+
+  it('notes & threads contract helpers', () => {
+    const note = shapeNote({ $id: 'n1', title: 'Idea 1' });
+    expect(note.id).toBe('n1');
+
+    const thread = shapeThread({ $id: 'th1', title: 'Thread 1' });
+    expect(thread.id).toBe('th1');
+
+    const msg = shapeThreadMessage({ $id: 'tm1', threadId: 'th1', content: 'hello' });
+    expect(msg.id).toBe('tm1');
+
+    const legacyComment = shapeLegacyThreadComment({ $id: 'lc1', userId: 'u1', content: 'legacy' }, 'th1');
+    expect(legacyComment.id).toBe('lc1');
+    expect(legacyComment.legacy).toBe(true);
+  });
+
+  it('auth contract helpers', () => {
+    const authProfile = shapeProfile({ userId: 'u1', kind: 'user', scopes: ['read'] });
+    expect(authProfile.id).toBe('u1');
+
+    const tokenMe = shapeTokenMe({ kind: 'session', userId: 'u1', scopes: ['read'] });
+    expect(tokenMe.userId).toBe('u1');
+
+    const tokenMePat = shapeTokenMe({ kind: 'pat', userId: 'u1', scopes: ['read'], patId: 'pat-1' });
+    expect(tokenMePat.patId).toBe('pat-1');
+
+    const catalog = shapeTokenScopeCatalog(['read', 'write']);
+    expect(catalog.scopes).toEqual(['read', 'write']);
+
+    const refresh = shapeTokenRefreshResult({ scopes: ['read'] }, 'hint-text');
+    expect(refresh.hint).toBe('hint-text');
+  });
+
+  it('chats, events, flows, forms, moments, tags, trash contract helpers', () => {
+    const chatListItem = shapeChatListItem({ $id: 'c1', name: 'General', participants: ['u1', 'u2'] });
+    expect(chatListItem.id).toBe('c1');
+
+    const chatDetail = shapeChatDetail({ $id: 'c1', name: 'General', participants: ['u1'] });
+    expect(chatDetail.participants).toEqual(['u1']);
+
+    const chatMsg = shapeChatMessage({ $id: 'm1', content: 'hello', isEncrypted: true }, true);
+    expect(chatMsg.id).toBe('m1');
+    expect(chatMsg.isEncrypted).toBe(true);
+
+    const eventListItem = shapeEventListItem({ $id: 'e1', title: 'Launch' });
+    expect(eventListItem.id).toBe('e1');
+
+    const eventDetail = shapeEventDetail({ $id: 'e1', title: 'Launch' });
+    expect(eventDetail.title).toBe('Launch');
+
+    expect(() => resolveFlowCreateFields({})).toThrow('name required');
+    const flowFields = resolveFlowCreateFields({ name: 'My Flow' });
+    expect(flowFields.name).toBe('My Flow');
+
+    const flowItem = shapeFlowListItem({ $id: 'fl1', name: 'Flow 1', steps: '[]' });
+    expect(flowItem.id).toBe('fl1');
+
+    const flowInstall = shapeFlowInstallListItem({ $id: 'i1', flowId: 'fl1' });
+    expect(flowInstall.flowId).toBe('fl1');
+
+    const formItem = shapeFormListItem({ $id: 'fm1', title: 'Feedback' });
+    expect(formItem.id).toBe('fm1');
+
+    const formDetail = shapeFormDetail({ $id: 'fm1', title: 'Feedback', schema: '[]' });
+    expect(formDetail.fields).toEqual([]);
+
+    const moment = shapeMoment({ $id: 'm1', caption: 'Great day' });
+    expect(moment.id).toBe('m1');
+
+    const momentNostr = shapeMomentCommentNostr({ id: 'n1', content: 'test', pubkey: 'p1', created_at: 1000 });
+    expect(momentNostr.id).toBe('n1');
+
+    const momentEco = shapeMomentCommentEcosystem({ $id: 'e1', caption: 'test' });
+    expect(momentEco.id).toBe('e1');
+
+    const momentCreated = shapeMomentCommentCreated({ id: 'c1', content: 'text', userId: 'u1', createdAt: 'now' });
+    expect(momentCreated.id).toBe('c1');
+
+    const tag = shapeTag({ $id: 't1', name: 'release', metadata: '{"color":"#fff","description":"desc"}' });
+    expect(tag.id).toBe('t1');
+    expect(tag.color).toBe('#fff');
+
+    const tagObjectMeta = shapeTag({ $id: 't2', metadata: { color: '#000', description: 'desc2' } });
+    expect(tagObjectMeta.color).toBe('#000');
+
+    expect(shapeTrashNoteItem({ $id: 'tr1', title: 'Note 1', content: 'Note content' }).kind).toBe('note');
+    expect(shapeTrashNoteItem({ id: 'tr1_alt', summary: 'Summary' }).summary).toBe('Summary');
+
+    expect(shapeTrashGoalItem({ $id: 'tr2', title: 'Goal 1', updatedAt: '2025-01-01' }).kind).toBe('goal');
+    expect(shapeTrashVaultItem({ $id: 'tr3', name: 'Secret 1', username: 'usr', url: 'https://site.com' }).kind).toBe('vault');
+    expect(shapeTrashEventItem({ $id: 'tr4', name: 'Event 1' }).kind).toBe('event');
+    expect(shapeTrashFormItem({ $id: 'tr5', name: 'Form 1' }).kind).toBe('form');
+  });
+});

--- a/sdk/crosslinks/index.test.ts
+++ b/sdk/crosslinks/index.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSourceNoteTag,
+  parseSourceNoteIdsFromTags,
+  buildSourceNoteTags,
+  buildVaultNoteTags,
+  buildNoteAttachmentMetadata,
+  NOTE_SOURCE_TAG_PREFIX,
+} from './index';
+
+describe('sdk/crosslinks', () => {
+  it('isSourceNoteTag checks prefix correctly', () => {
+    expect(isSourceNoteTag(`${NOTE_SOURCE_TAG_PREFIX}:note-123`)).toBe(true);
+    expect(isSourceNoteTag('regular-tag')).toBe(false);
+    expect(isSourceNoteTag('')).toBe(false);
+  });
+
+  it('parseSourceNoteIdsFromTags extracts note ids', () => {
+    const tags = [`${NOTE_SOURCE_TAG_PREFIX}:note-1`, 'other-tag', `${NOTE_SOURCE_TAG_PREFIX}:note-2`, null, undefined];
+    const ids = parseSourceNoteIdsFromTags(tags);
+    expect(ids).toEqual(['note-1', 'note-2']);
+  });
+
+  it('buildSourceNoteTags builds formatted unique tags', () => {
+    const tags = buildSourceNoteTags(['note-1', 'note-2', 'note-1', '', null]);
+    expect(tags).toEqual([
+      `${NOTE_SOURCE_TAG_PREFIX}:note-1`,
+      `${NOTE_SOURCE_TAG_PREFIX}:note-2`,
+    ]);
+  });
+
+  it('buildVaultNoteTags builds vault note tags', () => {
+    const tags = buildVaultNoteTags(['v1', 'v2', 'v1']);
+    expect(tags).toEqual(['note:v1', 'note:v2']);
+  });
+
+  it('buildNoteAttachmentMetadata builds metadata payload with defaults', () => {
+    const meta = buildNoteAttachmentMetadata({
+      $id: 'note-1',
+      title: 'My Title',
+      content: 'Hello world long content',
+    });
+    expect(meta).toEqual({
+      type: 'attachment',
+      entity: 'note',
+      subType: 'shared_note',
+      referenceId: 'note-1',
+      payload: {
+        label: 'My Title',
+        preview: 'Hello world long content',
+      },
+    });
+
+    const defaultMeta = buildNoteAttachmentMetadata({});
+    expect(defaultMeta.referenceId).toBeNull();
+    expect(defaultMeta.payload.label).toBe('Attached Note');
+    expect(defaultMeta.payload.preview).toBe('');
+  });
+});

--- a/sdk/ecosystem/index.test.ts
+++ b/sdk/ecosystem/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getLastActiveAppRedirectUrl } from './useLastActiveApp';
+
+describe('useLastActiveApp / getLastActiveAppRedirectUrl', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to connect dashboard when localStorage is empty', () => {
+    const url = getLastActiveAppRedirectUrl('https://app.kylrix.space/');
+    expect(url).toBe('https://app.kylrix.space/connect');
+  });
+
+  it('resolves correct dashboard URL for saved app in localStorage', () => {
+    localStorage.setItem('kylrix_last_active_app', 'note');
+    const url = getLastActiveAppRedirectUrl('https://app.kylrix.space');
+    expect(url).toBe('https://app.kylrix.space/app');
+
+    localStorage.setItem('kylrix_last_active_app', 'vault');
+    expect(getLastActiveAppRedirectUrl('https://app.kylrix.space')).toBe('https://app.kylrix.space/vault');
+
+    localStorage.setItem('kylrix_last_active_app', 'accounts');
+    expect(getLastActiveAppRedirectUrl('https://app.kylrix.space')).toBe('https://app.kylrix.space/accounts/settings/profile');
+
+    localStorage.setItem('kylrix_last_active_app', 'flow');
+    expect(getLastActiveAppRedirectUrl('https://app.kylrix.space')).toBe('https://app.kylrix.space/flow');
+  });
+});

--- a/sdk/identity/index.test.ts
+++ b/sdk/identity/index.test.ts
@@ -4,14 +4,26 @@ import { computeIdentityFlags, getUserProfilePicId, normalizeUsername, shortenUs
 describe('identity helpers', () => {
   it('normalizes usernames', () => {
     expect(normalizeUsername('@Kylrix')).toBe('kylrix');
+    expect(normalizeUsername('@@User')).toBe('user');
+    expect(normalizeUsername(null)).toBeNull();
+    expect(normalizeUsername('')).toBeNull();
   });
 
   it('resolves the best avatar source', () => {
-    expect(getUserProfilePicId({ prefs: { profilePicId: 'prefs-id' } })).toBe('prefs-id');
+    expect(getUserProfilePicId(null)).toBeNull();
+    expect(getUserProfilePicId({})).toBeNull();
+    expect(getUserProfilePicId({ avatarFileId: 'file-id' })).toBe('file-id');
     expect(getUserProfilePicId({ avatarUrl: 'avatar-url' })).toBe('avatar-url');
+    expect(getUserProfilePicId({ profilePicId: 'pic-id' })).toBe('pic-id');
+    expect(getUserProfilePicId({ avatar: 'avatar-id' })).toBe('avatar-id');
+    expect(getUserProfilePicId({ prefs: { profilePicId: 'prefs-id' } })).toBe('prefs-id');
+    expect(getUserProfilePicId({ preferences: { profilePicId: 'preferences-id' } })).toBe('preferences-id');
   });
 
   it('shortens ids consistently', () => {
+    expect(shortenUserId(null)).toBe('local');
+    expect(shortenUserId('')).toBe('local');
+    expect(shortenUserId('shortid')).toBe('shortid');
     expect(shortenUserId('1234567890abcdef')).toBe('123456…cdef');
   });
 
@@ -23,9 +35,17 @@ describe('identity helpers', () => {
       profilePicId: 'file-1',
       username: 'kylrix',
       bio: 'builds things',
-      tier: 'pro'});
+      tier: 'pro',
+    });
 
     expect(flags.verified).toBe(true);
     expect(flags.pro).toBe(true);
+
+    const unverified = computeIdentityFlags({
+      createdAt: null,
+      tier: 'free',
+    });
+    expect(unverified.verified).toBe(false);
+    expect(unverified.pro).toBe(false);
   });
 });

--- a/sdk/notes/index.test.ts
+++ b/sdk/notes/index.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createNoteCreationService } from './index';
+
+describe('createNoteCreationService', () => {
+  const mockUser = { $id: 'user-123' };
+
+  const setupDeps = (overrides = {}) => {
+    const getCurrentUser = vi.fn().mockResolvedValue(mockUser);
+    const createRow = vi.fn().mockImplementation((db, table, data, id) => Promise.resolve({ ...data, $id: id }));
+    const updateRow = vi.fn().mockImplementation((db, table, id, data) => Promise.resolve({ ...data, $id: id }));
+    const getNote = vi.fn().mockImplementation((id) => Promise.resolve({ $id: id, title: 'Sample Note' }));
+    const getNotePermissions = vi.fn().mockReturnValue(['read', 'write']);
+    const cleanRowData = vi.fn().mockImplementation((data) => ({ ...data }));
+    const filterNoteData = vi.fn().mockImplementation((data) => ({ ...data }));
+    const syncTags = vi.fn().mockResolvedValue(undefined);
+    const generateId = vi.fn().mockReturnValue('custom-note-id');
+
+    return {
+      databaseId: 'db1',
+      tableId: 'tbl1',
+      getCurrentUser,
+      createRow,
+      updateRow,
+      getNote,
+      getNotePermissions,
+      cleanRowData,
+      filterNoteData,
+      syncTags,
+      generateId,
+      ...overrides,
+    };
+  };
+
+  describe('createNote', () => {
+    it('throws error if user is not authenticated', async () => {
+      const deps = setupDeps({ getCurrentUser: vi.fn().mockResolvedValue(null) });
+      const service = createNoteCreationService(deps);
+      await expect(service.createNote({ title: 'Test' })).rejects.toThrow('User not authenticated');
+    });
+
+    it('creates note successfully with string/object metadata and tags', async () => {
+      const deps = setupDeps();
+      const service = createNoteCreationService(deps);
+
+      const result = await service.createNote({
+        title: ' My Long Title ',
+        content: 'Content',
+        tags: ['tag1', 'tag2', 'tag1', ''],
+        metadata: JSON.stringify({ key: 'val' }),
+        origin: { type: 'chat', id: 'c1' },
+        isPublic: true,
+      });
+
+      expect(deps.createRow).toHaveBeenCalled();
+      expect(deps.syncTags).toHaveBeenCalledWith({
+        noteId: 'custom-note-id',
+        rawTags: ['tag1', 'tag2'],
+        userId: 'user-123',
+        now: expect.any(String),
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('handles fallback ID generation when generateId is not provided', async () => {
+      const deps = setupDeps({ generateId: undefined });
+      const service = createNoteCreationService(deps);
+
+      const result = await service.createNote({ title: 'Test Fallback ID' });
+      expect(result).toBeDefined();
+      expect(deps.createRow).toHaveBeenCalled();
+    });
+
+    it('handles invalid JSON string metadata gracefully', async () => {
+      const deps = setupDeps();
+      const service = createNoteCreationService(deps);
+
+      await service.createNote({
+        title: 'Bad JSON',
+        metadata: 'invalid-json-{',
+      });
+
+      expect(deps.createRow).toHaveBeenCalledWith(
+        'db1',
+        'tbl1',
+        expect.objectContaining({
+          metadata: expect.stringContaining('_raw'),
+        }),
+        'custom-note-id',
+        expect.any(Array)
+      );
+    });
+
+    it('handles object metadata and raw noteData metadata string', async () => {
+      const deps = setupDeps({
+        cleanRowData: vi.fn().mockReturnValue({ metadata: '{"existing":"data"}' }),
+      });
+      const service = createNoteCreationService(deps);
+
+      await service.createNote({
+        title: 'Note Object Metadata',
+        metadata: { foo: 'bar' },
+      });
+
+      expect(deps.createRow).toHaveBeenCalled();
+    });
+
+    it('handles noteData with non-string metadata object', async () => {
+      const deps = setupDeps({
+        cleanRowData: vi.fn().mockReturnValue({ metadata: { existing: 'obj' } }),
+      });
+      const service = createNoteCreationService(deps);
+
+      await service.createNote({
+        title: 'Note Object Metadata',
+      });
+
+      expect(deps.createRow).toHaveBeenCalled();
+    });
+
+    it('handles noteData with invalid string metadata', async () => {
+      const deps = setupDeps({
+        cleanRowData: vi.fn().mockReturnValue({ metadata: 'invalid-base-json{' }),
+      });
+      const service = createNoteCreationService(deps);
+
+      await service.createNote({ title: 'Invalid base' });
+      expect(deps.createRow).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateNote', () => {
+    it('throws error if updateRow is not configured', async () => {
+      const deps = setupDeps({ updateRow: undefined });
+      const service = createNoteCreationService(deps);
+      await expect(service.updateNote('note-1', {})).rejects.toThrow('updateRow is not configured for note updates');
+    });
+
+    it('throws error if user is unauthenticated', async () => {
+      const deps = setupDeps({ getCurrentUser: vi.fn().mockResolvedValue(null) });
+      const service = createNoteCreationService(deps);
+      await expect(service.updateNote('note-1', {})).rejects.toThrow('User not authenticated');
+    });
+
+    it('updates note with title clamp, metadata parsing, and tags', async () => {
+      const deps = setupDeps();
+      const service = createNoteCreationService(deps);
+
+      await service.updateNote(
+        'note-1',
+        {
+          title: 'New Title',
+          metadata: '{"updated":true}',
+          kind: 'memo',
+          tags: ['t1', 't2'],
+          isPublic: false,
+        },
+        { ownerId: 'owner-99' }
+      );
+
+      expect(deps.getNotePermissions).toHaveBeenCalledWith('owner-99', false);
+      expect(deps.updateRow).toHaveBeenCalledWith(
+        'db1',
+        'tbl1',
+        'note-1',
+        expect.objectContaining({
+          title: 'New Title',
+          metadata: JSON.stringify({ updated: true, kind: 'memo' }),
+        }),
+        expect.any(Array)
+      );
+      expect(deps.syncTags).toHaveBeenCalledWith({
+        noteId: 'note-1',
+        rawTags: ['t1', 't2'],
+        userId: 'user-123',
+        now: expect.any(String),
+      });
+    });
+
+    it('updates note with object metadata and kind without metadata input', async () => {
+      const deps = setupDeps();
+      const service = createNoteCreationService(deps);
+
+      await service.updateNote('note-1', {
+        metadata: { direct: true },
+      });
+
+      expect(deps.updateRow).toHaveBeenCalledWith(
+        'db1',
+        'tbl1',
+        'note-1',
+        expect.objectContaining({
+          metadata: JSON.stringify({ direct: true }),
+        }),
+        undefined
+      );
+
+      await service.updateNote('note-2', {
+        kind: 'task',
+      });
+
+      expect(deps.updateRow).toHaveBeenCalledWith(
+        'db1',
+        'tbl1',
+        'note-2',
+        expect.objectContaining({
+          metadata: JSON.stringify({ kind: 'task' }),
+        }),
+        undefined
+      );
+    });
+
+    it('handles invalid json string metadata on update', async () => {
+      const deps = setupDeps();
+      const service = createNoteCreationService(deps);
+
+      await service.updateNote('note-1', {
+        metadata: 'bad-json-{',
+      });
+
+      expect(deps.updateRow).toHaveBeenCalledWith(
+        'db1',
+        'tbl1',
+        'note-1',
+        expect.objectContaining({
+          metadata: JSON.stringify({ _raw: 'bad-json-{' }),
+        }),
+        undefined
+      );
+    });
+  });
+});

--- a/sdk/orchestration/index.test.ts
+++ b/sdk/orchestration/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { createCrossObjectMetadata } from './index';
+
+describe('sdk/orchestration', () => {
+  it('creates cross object metadata with default values', () => {
+    const origin = {
+      sourceApp: 'note' as const,
+      sourceId: 'note-123',
+    };
+    const res = createCrossObjectMetadata(origin);
+    expect(res).toEqual({
+      sourceApp: 'note',
+      sourceId: 'note-123',
+      sourceKind: null,
+      sourceRoute: null,
+      surface: 'inline',
+      sourceLabel: null,
+      openMode: 'same-tab',
+      createdAt: expect.any(String),
+      minimized: true,
+      maximizedRoute: null,
+    });
+  });
+
+  it('creates cross object metadata with custom options and extra payload', () => {
+    const origin = {
+      sourceApp: 'vault' as const,
+      sourceId: 'v-1',
+      sourceKind: 'credential' as const,
+      sourceRoute: '/vault/item/1',
+      surface: 'drawer' as const,
+      sourceLabel: 'Vault Item',
+    };
+    const res = createCrossObjectMetadata(origin, {
+      openMode: 'drawer',
+      minimized: false,
+      maximizedRoute: '/vault/full',
+      extra: { foo: 'bar' },
+    });
+    expect(res).toEqual({
+      sourceApp: 'vault',
+      sourceId: 'v-1',
+      sourceKind: 'credential',
+      sourceRoute: '/vault/item/1',
+      surface: 'drawer',
+      sourceLabel: 'Vault Item',
+      openMode: 'drawer',
+      createdAt: expect.any(String),
+      minimized: false,
+      maximizedRoute: '/vault/full',
+      foo: 'bar',
+    });
+  });
+});

--- a/sdk/token/client.test.ts
+++ b/sdk/token/client.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createKylrixTokenOperationsClient } from './client';
+
+vi.mock('@/lib/actions/client-ops', () => ({
+  runTokenOperation: vi.fn().mockImplementation((req) => Promise.resolve({ ok: true, req })),
+}));
+
+vi.mock('@/lib/actions/secure-ops', () => ({
+  runTokenOperationSecure: vi.fn().mockImplementation((req) => Promise.resolve({ ok: true, req })),
+}));
+
+vi.mock('@/lib/actions/secure-ops/arbitrum-rail', () => ({
+  createPaymentIntentAction: vi.fn().mockImplementation((req) => Promise.resolve({ intentId: 'intent-123', ...req })),
+}));
+
+describe('createKylrixTokenOperationsClient', () => {
+  it('validates request actions and parameters correctly', async () => {
+    const client = createKylrixTokenOperationsClient();
+
+    // Invalid action / missing required fields
+    await expect(client.execute(null as any)).rejects.toThrow('TOKEN_CLIENT_INVALID_ACTION');
+    await expect(
+      client.mintActivity({
+        userId: '',
+        idempotencyKey: 'key',
+        activityType: 'daily_login',
+        uniqueActors: 1,
+        trustScore: 10,
+        sourceType: 'app',
+        sourceId: 'id1',
+      })
+    ).rejects.toThrow('TOKEN_CLIENT_INVALID_USERID');
+
+    await expect(
+      client.transfer({
+        fromUserId: 'u1',
+        toUserId: '',
+        amountMicro: '100',
+        idempotencyKey: 'k',
+        sourceType: 'app',
+        sourceId: 'id',
+      })
+    ).rejects.toThrow('TOKEN_CLIENT_INVALID_TOUSERID');
+
+    await expect(
+      client.fineToRoot({
+        userId: 'u1',
+        amountMicro: '',
+        idempotencyKey: 'k',
+        reason: 'abuse',
+        sourceType: 'app',
+        sourceId: 'id',
+      })
+    ).rejects.toThrow('TOKEN_CLIENT_INVALID_AMOUNTMICRO');
+
+    await expect(
+      client.lockClaim({
+        userId: 'u1',
+        amountMicro: '100',
+        destinationWallet: '',
+        chain: 'arbitrum',
+        idempotencyKey: 'k',
+      })
+    ).rejects.toThrow('TOKEN_CLIENT_INVALID_DESTINATIONWALLET');
+
+    await expect(
+      client.settleClaim({
+        userId: 'u1',
+        amountMicro: '100',
+        destinationWallet: '0x123',
+        chain: 'arbitrum',
+        onchainTxHash: '',
+        idempotencyKey: 'k',
+      })
+    ).rejects.toThrow('TOKEN_CLIENT_INVALID_ONCHAINTXHASH');
+  });
+
+  it('executes server actions with resolved JWT and custom endpoint options', async () => {
+    const getJwt = vi.fn().mockResolvedValue('jwt-token-xyz');
+    const client = createKylrixTokenOperationsClient({
+      endpoint: 'custom-endpoint',
+      headers: { 'X-Custom': '1' },
+      getJwt,
+    });
+
+    const state = await client.getState();
+    expect(getJwt).toHaveBeenCalled();
+    expect(state).toBeDefined();
+
+    const init = await client.initializeState();
+    expect(init).toBeDefined();
+
+    const balance = await client.getBalance();
+    expect(balance).toBeDefined();
+
+    const ledger = await client.listLedger();
+    expect(ledger).toBeDefined();
+  });
+
+  it('handles requestPaymentIntent correctly', async () => {
+    const getJwt = vi.fn().mockResolvedValue('jwt-token-123');
+    const client = createKylrixTokenOperationsClient({ getJwt });
+
+    const res = await client.requestPaymentIntent('agent-1', 10, { ref: '123' }, 42161);
+    expect(res).toEqual({
+      jwt: 'jwt-token-123',
+      agentId: 'agent-1',
+      amount: 10,
+      contextPayload: { ref: '123' },
+      chainId: 42161,
+      intentId: 'intent-123',
+    });
+  });
+});

--- a/sdk/token/contract.test.ts
+++ b/sdk/token/contract.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createKylrixTokenContract,
+  DEFAULT_KYLRIX_TOKEN_POLICY,
+  type KylrixEmissionSnapshot,
+  type KylrixActivitySignal,
+} from './contract';
+
+describe('createKylrixTokenContract', () => {
+  const contract = createKylrixTokenContract();
+
+  it('uses default policy', () => {
+    expect(contract.policy.symbol).toBe('$KYLRIX');
+    expect(contract.policy.decimals).toBe(6);
+  });
+
+  it('calculates circulating micro tokens', () => {
+    const snapshot: KylrixEmissionSnapshot = {
+      mintedMicro: 1000n,
+      burnedMicro: 200n,
+      genesisAt: '2025-01-01T00:00:00Z',
+    };
+    expect(contract.circulatingMicro(snapshot)).toBe(800n);
+
+    // Negative circulating prevented
+    const snapshotNeg: KylrixEmissionSnapshot = {
+      mintedMicro: 100n,
+      burnedMicro: 200n,
+      genesisAt: '2025-01-01T00:00:00Z',
+    };
+    expect(contract.circulatingMicro(snapshotNeg)).toBe(0n);
+  });
+
+  it('calculates age in days accurately', () => {
+    expect(contract.getAgeDays({ mintedMicro: 0n, burnedMicro: 0n, genesisAt: null })).toBe(0);
+    expect(contract.getAgeDays({ mintedMicro: 0n, burnedMicro: 0n, genesisAt: 'invalid-date' })).toBe(0);
+
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    expect(contract.getAgeDays({ mintedMicro: 0n, burnedMicro: 0n, genesisAt: twoDaysAgo })).toBe(2);
+  });
+
+  it('calculates emission budget and remaining budget', () => {
+    const snapshot: KylrixEmissionSnapshot = {
+      mintedMicro: 10_000n,
+      burnedMicro: 0n,
+      genesisAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    const budget = contract.emissionBudgetForAge(snapshot);
+    expect(budget).toBeGreaterThan(0n);
+
+    const remaining = contract.remainingEmissionBudget(snapshot);
+    expect(remaining).toBe(budget - 10_000n);
+
+    // Exhausted budget
+    const overSnapshot: KylrixEmissionSnapshot = {
+      mintedMicro: budget + 5000n,
+      burnedMicro: 0n,
+      genesisAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    expect(contract.remainingEmissionBudget(overSnapshot)).toBe(0n);
+  });
+
+  describe('decideMintForActivity', () => {
+    const validSnapshot: KylrixEmissionSnapshot = {
+      mintedMicro: 0n,
+      burnedMicro: 0n,
+      genesisAt: '2020-01-01T00:00:00.000Z',
+    };
+
+    const validSignal: KylrixActivitySignal = {
+      activityType: 'note_create',
+      uniqueActors: 5,
+      trustScore: 50,
+      recentSpikeFactorBps: 0,
+      accountAgeDays: 30,
+      userBaseCount: 200,
+    };
+
+    it('denies unsupported activity', () => {
+      const res = contract.decideMintForActivity(
+        validSnapshot,
+        { ...validSignal, activityType: 'unknown_act' as any },
+        0n
+      );
+      expect(res.allowed).toBe(false);
+      expect(res.reason).toBe('UNSUPPORTED_ACTIVITY');
+    });
+
+    it('denies zero or negative unique actors', () => {
+      const res = contract.decideMintForActivity(validSnapshot, { ...validSignal, uniqueActors: 0 }, 0n);
+      expect(res.allowed).toBe(false);
+      expect(res.reason).toBe('NO_UNIQUE_ACTIVITY');
+    });
+
+    it('allows valid minting decision with scale and age boost', () => {
+      const res = contract.decideMintForActivity(validSnapshot, validSignal, 0n);
+      expect(res.allowed).toBe(true);
+      expect(res.amountMicro).toBeGreaterThan(0n);
+    });
+
+    it('handles various user base scales', () => {
+      const scales = [50, 200, 2000, 20000, 100000];
+      scales.forEach((userBaseCount) => {
+        const res = contract.decideMintForActivity(validSnapshot, { ...validSignal, userBaseCount }, 0n);
+        expect(res.allowed).toBe(true);
+      });
+    });
+
+    it('applies penalties for low trust, recent activity, thermal score, and low friction activity types', () => {
+      const penaltySignal: KylrixActivitySignal = {
+        activityType: 'chat_message',
+        uniqueActors: 1,
+        trustScore: 10, // low trust penalty
+        recentSpikeFactorBps: 2000, // spike penalty
+        recentActivityCount: 10, // repeat penalty
+        accountAgeDays: 5,
+        thermalScore: 5, // high thermal penalty
+      };
+      const res = contract.decideMintForActivity(validSnapshot, penaltySignal, 0n);
+      expect(res.tightenBps).toBeDefined();
+    });
+
+    it('denies when daily cap reached or limits amount to daily cap', () => {
+      const capReachedRes = contract.decideMintForActivity(
+        validSnapshot,
+        validSignal,
+        DEFAULT_KYLRIX_TOKEN_POLICY.dailyMintCapMicro
+      );
+      expect(capReachedRes.allowed).toBe(false);
+      expect(capReachedRes.reason).toBe('USER_DAILY_CAP_REACHED');
+
+      const nearCapRes = contract.decideMintForActivity(
+        validSnapshot,
+        validSignal,
+        DEFAULT_KYLRIX_TOKEN_POLICY.dailyMintCapMicro - 100n
+      );
+      expect(nearCapRes.allowed).toBe(true);
+      expect(nearCapRes.amountMicro).toBeLessThanOrEqual(100n);
+    });
+
+    it('denies when emission budget or max supply exhausted', () => {
+      const budget = contract.emissionBudgetForAge(validSnapshot);
+      const noBudgetSnapshot: KylrixEmissionSnapshot = {
+        mintedMicro: budget + 1000n,
+        burnedMicro: 0n,
+        genesisAt: '2020-01-01T00:00:00.000Z',
+      };
+      const res = contract.decideMintForActivity(noBudgetSnapshot, validSignal, 0n);
+      expect(res.allowed).toBe(false);
+      expect(res.reason).toBe('EMISSION_BUDGET_EXHAUSTED');
+    });
+
+    it('denies when max supply reached', () => {
+      const maxSupplySnapshot: KylrixEmissionSnapshot = {
+        mintedMicro: DEFAULT_KYLRIX_TOKEN_POLICY.maxSupplyMicro,
+        burnedMicro: 0n,
+        genesisAt: '2020-01-01T00:00:00.000Z',
+      };
+      const res = contract.decideMintForActivity(maxSupplySnapshot, validSignal, 0n);
+      expect(res.allowed).toBe(false);
+      expect(['EMISSION_BUDGET_EXHAUSTED', 'MAX_SUPPLY_REACHED']).toContain(res.reason);
+    });
+  });
+
+  describe('validateTransfer', () => {
+    it('invalidates zero or negative transfer amounts', () => {
+      expect(contract.validateTransfer(0n)).toEqual({ allowed: false, reason: 'INVALID_TRANSFER_AMOUNT' });
+      expect(contract.validateTransfer(-100n)).toEqual({ allowed: false, reason: 'INVALID_TRANSFER_AMOUNT' });
+    });
+
+    it('invalidates transfer amounts above single transfer limit', () => {
+      const overLimit = DEFAULT_KYLRIX_TOKEN_POLICY.maxSingleTransferMicro + 1n;
+      expect(contract.validateTransfer(overLimit)).toEqual({ allowed: false, reason: 'TRANSFER_LIMIT_EXCEEDED' });
+    });
+
+    it('validates correct transfer amounts', () => {
+      expect(contract.validateTransfer(100n)).toEqual({ allowed: true, reason: null });
+    });
+  });
+});

--- a/sdk/topbar/index.test.ts
+++ b/sdk/topbar/index.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createConnectTopbarSurface, createTopbarAction, createTopbarSurface, topbarMatches } from './index';
+import {
+  createConnectTopbarSurface,
+  createTopbarAction,
+  createTopbarSurface,
+  createEcosystemPanelItems,
+  createTopbarPanelMotion,
+  createTopbarSearchSurface,
+  isTopbarScrollAtTop,
+  topbarMatches,
+} from './index';
 
 describe('topbar helpers', () => {
   it('matches queries against terms', () => {
@@ -15,9 +24,20 @@ describe('topbar helpers', () => {
       description: 'Capture a note',
       terms: ['draft'],
       onSelect: vi.fn(),
-      app: 'note'});
+      app: 'note',
+    });
 
     expect(action.accent).toBe('#EC4899');
+
+    const defaultAccent = createTopbarAction({
+      id: 'custom',
+      kind: 'custom',
+      title: 'Title',
+      description: 'Desc',
+      terms: ['custom'],
+      onSelect: vi.fn(),
+    });
+    expect(defaultAccent.accent).toBeDefined();
   });
 
   it('attaches the shared layout model', () => {
@@ -26,7 +46,8 @@ describe('topbar helpers', () => {
       currentApp: 'note',
       snippets: [],
       quickActions: [],
-      searchTargets: []});
+      searchTargets: [],
+    });
 
     expect(surface.layout.height).toBe(88);
     expect(surface.layout.searchDockMaxHeight).toBe('50vh');
@@ -37,10 +58,64 @@ describe('topbar helpers', () => {
       identity: {
         displayName: 'Kylrix User',
         username: 'kylrix',
-        walletConnected: true}});
+        walletConnected: true,
+      },
+    });
 
     expect(surface.currentApp).toBe('connect');
     expect(surface.identity.displayName).toBe('Kylrix User');
     expect(surface.showConnectCta).toBe(false);
+
+    const disconnectedSurface = createConnectTopbarSurface({
+      identity: {
+        displayName: 'Guest',
+        walletConnected: false,
+      },
+    });
+    expect(disconnectedSurface.showConnectCta).toBe(true);
+  });
+
+  it('creates ecosystem panel items with selected indicator', () => {
+    const items = createEcosystemPanelItems('vault');
+    expect(items.length).toBe(5);
+    expect(items.find((i) => i.app === 'vault')?.selected).toBe(true);
+    expect(items.find((i) => i.app === 'note')?.selected).toBe(false);
+  });
+
+  it('creates topbar panel motion object', () => {
+    const motion = createTopbarPanelMotion();
+    expect(motion.initial.opacity).toBe(0);
+    expect(motion.animate.opacity).toBe(1);
+  });
+
+  it('creates topbar search surface with query pool and hints', () => {
+    const resolveUrl = (app: string, path?: string) => `https://${app}.kylrix.space${path || ''}`;
+    const searchSurface = createTopbarSearchSurface({
+      query: 'note',
+      routeLabel: 'Connect',
+      currentApp: 'connect',
+      snippets: [
+        { id: 'snip-1', kind: 'goal', title: 'Goal snippet', description: 'Desc', href: null },
+        { id: 'snip-2', kind: 'moment', title: 'Moment snippet', description: 'Desc2' },
+        { id: 'snip-3', kind: 'call', title: 'Call snippet', description: 'Desc3' },
+        { id: 'snip-4', kind: 'other', title: 'Other snippet', description: 'Desc4' },
+      ],
+      resolveUrl,
+    });
+
+    expect(searchSurface.query).toBe('note');
+    expect(searchSurface.quickActions.length).toBeGreaterThan(0);
+
+    const emptyQuerySurface = createTopbarSearchSurface({
+      query: '',
+      resolveUrl,
+    });
+    expect(emptyQuerySurface.query).toBe('');
+  });
+
+  it('checks topbar scroll top status', () => {
+    expect(isTopbarScrollAtTop(null)).toBe(false);
+    expect(isTopbarScrollAtTop({ scrollTop: 0 } as any)).toBe(true);
+    expect(isTopbarScrollAtTop({ scrollTop: 10 } as any)).toBe(false);
   });
 });

--- a/utils/import/bitwarden-mapper.test.ts
+++ b/utils/import/bitwarden-mapper.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeBitwardenExport, validateBitwardenExport } from './bitwarden-mapper';
+import { BITWARDEN_ITEM_TYPES } from './bitwarden-types';
+
+describe('bitwarden-mapper', () => {
+  const validExport = {
+    encrypted: false,
+    folders: [{ id: 'f-1', name: 'Work' }],
+    items: [
+      {
+        id: 'item-1',
+        type: BITWARDEN_ITEM_TYPES.LOGIN,
+        name: 'GitHub',
+        folderId: 'f-1',
+        notes: 'Personal account',
+        favorite: true,
+        creationDate: '2025-01-01T00:00:00Z',
+        revisionDate: '2025-01-02T00:00:00Z',
+        login: {
+          username: 'octocat',
+          password: 'super-secret-password',
+          totp: 'JBSWY3DPEHPK3PXP',
+          uris: [{ uri: 'https://github.com' }],
+        },
+        fields: [{ name: 'Security PIN', value: '1234' }],
+      },
+      {
+        id: 'item-2',
+        type: BITWARDEN_ITEM_TYPES.NOTE, // non-login item, skipped
+        name: 'Secure Note',
+      },
+      {
+        id: 'item-3',
+        type: BITWARDEN_ITEM_TYPES.LOGIN,
+        name: 'Incomplete Item',
+        login: { username: '', password: '' }, // missing required fields, skipped
+      },
+    ],
+  };
+
+  it('validates bitwarden export structure correctly', () => {
+    expect(validateBitwardenExport(validExport)).toBe(true);
+    expect(validateBitwardenExport(null)).toBe(false);
+    expect(validateBitwardenExport({})).toBe(false);
+    expect(validateBitwardenExport({ encrypted: false, folders: [] })).toBe(false);
+  });
+
+  it('analyzes and maps Bitwarden export data correctly', () => {
+    const userId = 'user-123';
+    const result = analyzeBitwardenExport(validExport as any, userId);
+
+    expect(result.folders.length).toBe(1);
+    expect(result.folders[0].name).toBe('Work');
+
+    expect(result.credentials.length).toBe(1);
+    expect(result.credentials[0].name).toBe('GitHub');
+    expect(result.credentials[0].username).toBe('octocat');
+    expect(result.credentials[0].password).toBe('super-secret-password');
+    expect(result.credentials[0].url).toBe('https://github.com');
+    expect(result.credentials[0].customFields).toBe(JSON.stringify({ 'Security PIN': '1234' }));
+
+    expect(result.totpSecrets.length).toBe(1);
+    expect(result.totpSecrets[0].secretKey).toBe('JBSWY3DPEHPK3PXP');
+
+    expect(result.mapping.statistics.totalItems).toBe(3);
+    expect(result.mapping.statistics.credentialsCount).toBe(1);
+    expect(result.mapping.statistics.skippedItems).toBe(2);
+  });
+});

--- a/utils/import/encrypted-html-exporter.test.ts
+++ b/utils/import/encrypted-html-exporter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sealPlaintextExport,
+  encryptExportData,
+  tryCreatePasskeyWrapKey,
+  generateEncryptedHtmlPage,
+} from './encrypted-html-exporter';
+
+describe('encrypted-html-exporter', () => {
+  const sampleData = JSON.stringify({ vault: { credentials: [], totpSecrets: [] } });
+  const masterPassword = 'MasterPassword123!';
+
+  it('seals plaintext data with AES-GCM and PBKDF2', async () => {
+    const bundle = await sealPlaintextExport(sampleData, masterPassword, null);
+    expect(bundle.ciphertext).toBeDefined();
+    expect(bundle.salt).toBeDefined();
+    expect(bundle.iv).toBeDefined();
+    expect(bundle.wrappedDekPassword).toBeDefined();
+    expect(bundle.passkey).toBeNull();
+  });
+
+  it('seals plaintext data with passkey wrap option', async () => {
+    const prfKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+      'wrapKey',
+      'unwrapKey',
+      'encrypt',
+      'decrypt',
+    ]);
+    const prfSalt = new Uint8Array(32);
+    const bundle = await sealPlaintextExport(sampleData, masterPassword, {
+      credentialId: 'cred-123',
+      prfKey,
+      prfSalt,
+    });
+
+    expect(bundle.passkey).toBeDefined();
+    expect(bundle.passkey?.credentialId).toBe('cred-123');
+  });
+
+  it('encryptExportData deprecated wrapper works identically', async () => {
+    const bundle = await encryptExportData(sampleData, masterPassword);
+    expect(bundle.ciphertext).toBeDefined();
+    expect(bundle.wrappedDekPassword).toBeDefined();
+  });
+
+  it('tryCreatePasskeyWrapKey returns null when PublicCredential or WebAuthn is unavailable', async () => {
+    const wrap = await tryCreatePasskeyWrapKey();
+    expect(wrap).toBeNull();
+  });
+
+  it('generates HTML backup page string with embedded bundle and username', async () => {
+    const bundle = await sealPlaintextExport(sampleData, masterPassword, null);
+    const html = generateEncryptedHtmlPage(bundle, 'testuser');
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('Locked backup · testuser');
+    expect(html).toContain(bundle.ciphertext);
+
+    const legacyHtml = generateEncryptedHtmlPage(
+      { ciphertext: 'c', salt: 's', iv: 'i' },
+      'legacyuser'
+    );
+    expect(legacyHtml).toContain('legacyuser');
+  });
+});

--- a/utils/import/generic-parser.test.ts
+++ b/utils/import/generic-parser.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { parseCSV, detectColumnMapping, mapRowsToItems } from './generic-parser';
+
+describe('generic-parser', () => {
+  it('parses CSV strings with quotes and comma/semicolon delimiters', () => {
+    const csv = `Title,Username,Password,URL,Notes
+"My App",user@test.com,"p@ss,word","https://example.com","some notes"
+"Semi App";admin;123456;"https://semi.com";""`;
+
+    const rows = parseCSV(csv);
+    expect(rows.length).toBe(3);
+    expect(rows[0]).toEqual(['Title', 'Username', 'Password', 'URL', 'Notes']);
+    expect(rows[1]).toEqual(['My App', 'user@test.com', 'p@ss,word', 'https://example.com', 'some notes']);
+    expect(rows[2]).toEqual(['Semi App', 'admin', '123456', 'https://semi.com', '']);
+  });
+
+  it('detects column mappings from headers', () => {
+    const rows = [
+      ['Name', 'Login Email', 'Password', 'Website', 'Comments'],
+      ['App', 'user@test.com', 'pass', 'https://test.com', 'notes'],
+    ];
+    const mapping = detectColumnMapping(rows);
+    expect(mapping.nameIdx).toBe(0);
+    expect(mapping.usernameIdx).toBe(1);
+    expect(mapping.passwordIdx).toBe(2);
+    expect(mapping.urlIdx).toBe(3);
+    expect(mapping.notesIdx).toBe(4);
+  });
+
+  it('detects column mappings from values when no headers are present', () => {
+    const rows = [
+      ['Item1', 'admin@site.org', 'S3cur3!Pass123', 'https://site.org'],
+    ];
+    const mapping = detectColumnMapping(rows);
+    expect(mapping.usernameIdx).toBe(1);
+    expect(mapping.passwordIdx).toBe(2);
+    expect(mapping.urlIdx).toBe(3);
+  });
+
+  it('handles empty rows array in detectColumnMapping', () => {
+    expect(detectColumnMapping([])).toEqual({
+      nameIdx: -1,
+      usernameIdx: -1,
+      passwordIdx: -1,
+      urlIdx: -1,
+      notesIdx: -1,
+    });
+  });
+
+  it('maps CSV rows to ImportItems using mapping with or without header', () => {
+    const rows = [
+      ['Title', 'User', 'Pass', 'URL', 'Notes'],
+      ['Gmail', 'user@gmail.com', 'secret123', 'https://gmail.com', 'Personal mail'],
+      ['', 'anon@gmail.com', 'pass456', '', ''],
+    ];
+    const mapping = {
+      nameIdx: 0,
+      usernameIdx: 1,
+      passwordIdx: 2,
+      urlIdx: 3,
+      notesIdx: 4,
+    };
+    const items = mapRowsToItems(rows, mapping, true);
+    expect(items.length).toBe(2);
+    expect(items[0].name).toBe('Gmail');
+    expect(items[1].name).toBe('Imported Item 2');
+
+    const noHeaderItems = mapRowsToItems([['App', 'usr', 'pwd']], { nameIdx: 0, usernameIdx: 1, passwordIdx: 2, urlIdx: -1, notesIdx: -1 }, false);
+    expect(noHeaderItems.length).toBe(1);
+  });
+});

--- a/utils/import/import-service.test.ts
+++ b/utils/import/import-service.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ImportService } from './import-service';
+
+vi.mock('@/lib/appwrite', () => ({
+  createFolder: vi.fn().mockImplementation((folder) => Promise.resolve({ $id: `folder-${folder.name}`, name: folder.name })),
+  AppwriteService: {
+    listFolders: vi.fn().mockResolvedValue([{ $id: 'f-existing', name: 'Existing Workspace' }]),
+  },
+}));
+
+vi.mock('@/lib/appwrite/vault-service', () => ({
+  VaultService: {
+    stageCredentialImport: vi.fn().mockResolvedValue({ $id: 'cred-1' }),
+    stageTotpImport: vi.fn().mockResolvedValue({ $id: 'totp-1' }),
+  },
+}));
+
+vi.mock('@/lib/vault/import-local-batch', () => ({
+  startImportBatch: vi.fn().mockResolvedValue('batch-123'),
+  kickImportSync: vi.fn(),
+}));
+
+vi.mock('@/lib/porter/sanitize-import', () => ({
+  sanitizeImportBundle: vi.fn().mockImplementation((bundle) => ({
+    credentials: bundle.credentials || [],
+    totpSecrets: bundle.totpSecrets || [],
+    workspaces: bundle.workspaces || bundle.folders || [],
+    folders: bundle.folders || [],
+    skippedInvalid: 0,
+    skippedDuplicate: 0,
+    skippedDuplicateIncoming: 0,
+  })),
+  loadExistingVaultForDedupe: vi.fn().mockResolvedValue({ credentials: [], totpSecrets: [] }),
+}));
+
+describe('ImportService', () => {
+  const userId = 'user-test-123';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('importBitwardenData', () => {
+    it('fails when JSON format is invalid', async () => {
+      const progressFn = vi.fn();
+      const service = new ImportService(progressFn);
+
+      const result = await service.importBitwardenData(JSON.stringify({ encrypted: true }), userId);
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(progressFn).toHaveBeenCalledWith(expect.objectContaining({ stage: 'error' }));
+    });
+
+    it('fails when no credentials are present in Bitwarden export', async () => {
+      const service = new ImportService();
+      const exportNoCreds = {
+        encrypted: false,
+        folders: [],
+        items: [],
+      };
+
+      const result = await service.importBitwardenData(JSON.stringify(exportNoCreds), userId);
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain('No login credentials found');
+    });
+
+    it('successfully imports valid Bitwarden export', async () => {
+      const progressFn = vi.fn();
+      const service = new ImportService(progressFn);
+      const validBitwardenExport = {
+        encrypted: false,
+        folders: [{ id: 'f1', name: 'Work' }],
+        items: [
+          {
+            id: 'item-1',
+            type: 1,
+            name: 'GitHub',
+            folderId: 'f1',
+            login: {
+              username: 'user1',
+              password: 'pass1',
+              totp: 'JBSWY3DPEHPK3PXP',
+              uris: [{ uri: 'https://github.com' }],
+            },
+          },
+        ],
+      };
+
+      const result = await service.importBitwardenData(JSON.stringify(validBitwardenExport), userId);
+
+      expect(result.success).toBe(true);
+      expect(result.summary.credentialsCreated).toBe(1);
+      expect(result.summary.totpSecretsCreated).toBe(1);
+      expect(progressFn).toHaveBeenCalledWith(expect.objectContaining({ stage: 'completed' }));
+    });
+  });
+
+  describe('importKylrixVaultData', () => {
+    it('fails when export format is invalid', async () => {
+      const service = new ImportService();
+      const result = await service.importKylrixVaultData(JSON.stringify({ invalid: 'data' }), userId);
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain('Invalid Kylrix Vault export format');
+    });
+
+    it('successfully imports valid Kylrix Vault export with all optional fields and folder mappings', async () => {
+      const progressFn = vi.fn();
+      const service = new ImportService(progressFn);
+      const validVaultExport = {
+        version: 1,
+        workspaces: [{ $id: 'w1', name: 'Dev Workspace' }],
+        credentials: [
+          {
+            name: 'AWS Console',
+            username: 'admin',
+            password: 'secretpassword',
+            url: 'https://aws.amazon.com',
+            notes: 'AWS root account',
+            folderId: 'w1',
+            tags: ['cloud', 'aws'],
+            customFields: { env: 'production' },
+            totpId: 'totp-123',
+            cardNumber: '4111',
+            cardholderName: 'Admin',
+            cardExpiry: '12/28',
+            cardCVV: '123',
+            cardPIN: '9999',
+            cardType: 'visa',
+            faviconUrl: 'https://aws.com/favicon.ico',
+            _mergeTargetId: 'merge-target-1',
+          },
+        ],
+        totpSecrets: [
+          {
+            issuer: 'AWS',
+            accountName: 'admin',
+            secretKey: 'JBSWY3DPEHPK3PXP',
+            folderId: 'w1',
+            url: 'https://aws.amazon.com',
+            tags: ['2fa'],
+            isFavorite: true,
+            isDeleted: false,
+            _mergeTargetId: 'totp-merge-1',
+          },
+        ],
+      };
+
+      const result = await service.importKylrixVaultData(JSON.stringify(validVaultExport), userId);
+
+      expect(result.success).toBe(true);
+      expect(result.summary.foldersCreated).toBe(1);
+      expect(result.summary.credentialsCreated).toBe(1);
+      expect(result.summary.totpSecretsCreated).toBe(1);
+      expect(progressFn).toHaveBeenCalledWith(expect.objectContaining({ stage: 'completed' }));
+    });
+  });
+});

--- a/utils/import/totp-parser.test.ts
+++ b/utils/import/totp-parser.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { parseTotpData, extractTotpFromBitwardenLogin } from './totp-parser';
+
+describe('totp-parser', () => {
+  it('parses otpauth totp URIs accurately', () => {
+    const uri = 'otpauth://totp/GitHub:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=GitHub&algorithm=SHA256&digits=8&period=60';
+    const parsed = parseTotpData(uri);
+    expect(parsed).toEqual({
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      issuer: 'GitHub',
+      accountName: 'user@example.com',
+      algorithm: 'SHA256',
+      digits: 8,
+      period: 60,
+    });
+  });
+
+  it('parses otpauth hotp URIs', () => {
+    const uri = 'otpauth://hotp/Service:acc?secret=JBSWY3DPEHPK3PXP';
+    const parsed = parseTotpData(uri);
+    expect(parsed).toBeDefined();
+    expect(parsed?.secretKey).toBe('JBSWY3DPEHPK3PXP');
+  });
+
+  it('handles otpauth URIs with single path part and issuer param', () => {
+    const uri = 'otpauth://totp/accountOnly?secret=JBSWY3DPEHPK3PXP&issuer=ParamIssuer';
+    const parsed = parseTotpData(uri);
+    expect(parsed?.accountName).toBe('accountOnly');
+    expect(parsed?.issuer).toBe('ParamIssuer');
+  });
+
+  it('returns null for bad protocols, unknown kinds, or missing secret in otpauth URIs', () => {
+    expect(parseTotpData('http://totp/acc?secret=JBSWY3DPEHPK3PXP')).toBeNull();
+    expect(parseTotpData('otpauth://invalidkind/acc?secret=JBSWY3DPEHPK3PXP')).toBeNull();
+    expect(parseTotpData('otpauth://totp/acc')).toBeNull();
+  });
+
+  it('parses bare base32 and hex secrets', () => {
+    const base32 = parseTotpData('JBSWY3DPEHPK3PXP');
+    expect(base32).toEqual({
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      issuer: 'Unknown',
+      accountName: 'Unknown',
+      algorithm: 'SHA1',
+      digits: 6,
+      period: 30,
+    });
+
+    const hex = parseTotpData('1234567890ABCDEF1234567890ABCDEF');
+    expect(hex).toBeDefined();
+  });
+
+  it('returns null for invalid URIs or secrets', () => {
+    expect(parseTotpData('invalid')).toBeNull();
+    expect(parseTotpData('http://invalid.com')).toBeNull();
+  });
+
+  it('extracts TOTP from Bitwarden login object', () => {
+    const res = extractTotpFromBitwardenLogin(
+      { totp: 'JBSWY3DPEHPK3PXP', username: 'john_doe' },
+      'Amazon - Personal'
+    );
+    expect(res).toEqual({
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      issuer: 'Amazon',
+      accountName: 'john_doe',
+      algorithm: 'SHA1',
+      digits: 6,
+      period: 30,
+    });
+
+    expect(extractTotpFromBitwardenLogin({ totp: null }, 'Item')).toBeNull();
+  });
+});

--- a/utils/patternGenerator.test.ts
+++ b/utils/patternGenerator.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { generateEventPattern } from './patternGenerator';
+
+describe('patternGenerator', () => {
+  it('generates deterministic gradient patterns for a seed string', () => {
+    const pattern1 = generateEventPattern('event-123');
+    const pattern2 = generateEventPattern('event-123');
+    expect(pattern1).toBe(pattern2);
+    expect(pattern1).toContain('gradient');
+  });
+
+  it('generates different patterns for different seed strings', () => {
+    const patternA = generateEventPattern('seed-A');
+    const patternB = generateEventPattern('seed-B');
+    expect(patternA).toBeDefined();
+    expect(patternB).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       include: ['sdk/**', 'utils/**'],
-      exclude: ['**/*.d.ts', '**/*.config.*', '__tests__/**'],
+      exclude: ['**/*.d.ts', '**/*.config.*', '__tests__/**', '**/*.md'],
       thresholds: {
         statements: 85,
         branches: 80,


### PR DESCRIPTION
Adds comprehensive unit test coverage for SDK core, contracts, notes creation service, token contract & operations client, orchestration, crosslinks, ecosystem discovery, pattern generator, and vault import utilities. Updates vitest configuration to exclude markdown files from V8 coverage. All tests pass cleanly and meet coverage thresholds.

---
*PR created automatically by Jules for task [4737052171514611542](https://jules.google.com/task/4737052171514611542) started by @nathfavour*