### PR TITLE
Introduce KYLRIX_CLOUD flag and make workspace collaborators free and unlimited

### DIFF
--- a/components/overlays/ShareNoteDrawer.tsx
+++ b/components/overlays/ShareNoteDrawer.tsx
@@ -10,9 +10,6 @@ import UserSearch from '@/components/UserSearch';
 import { useAuth } from '@/context/auth/AuthContext';
 import { account } from '@/lib/appwrite/client';
 import { IdentityAvatar } from '@/components/common/IdentityBadge';
-import { hasPaidKylrixPlan, hasTeamsKylrixPlan } from '@/lib/utils';
-import { useProUpgrade } from '@/context/ProUpgradeContext';
-import { useSubscription } from '@/context/subscription/SubscriptionContext';
 import toast from 'react-hot-toast';
 
 // Unified config builder for dynamic resource terminology & branding
@@ -124,9 +121,6 @@ export function ShareNoteDrawer({ isOpen, onClose, noteId, noteTitle, resourceTy
   const { setIsDrawerOpen } = useDrawerState();
   const { drawerData, open } = useUnifiedDrawer();
   const { user } = useAuth();
-  const { openProUpgrade } = useProUpgrade();
-  const { currentTier } = useSubscription();
-  
   const [selectedUsers, setSelectedUsers] = useState<any[]>([]);
   const [collaboratorProfiles, setCollaboratorProfiles] = useState<any[]>([]);
   const [isLoadingExisting, setIsLoadingExisting] = useState(false);
@@ -243,20 +237,6 @@ export function ShareNoteDrawer({ isOpen, onClose, noteId, noteTitle, resourceTy
 
   const handleGrant = async () => {
     if (selectedUsers.length === 0 || !user?.$id) return;
-
-    if (resourceType === 'project' && !hasTeamsKylrixPlan(user, currentTier)) {
-      toast.error('Project collaboration requires a Teams subscription on the project owner account.');
-      openProUpgrade('Projects');
-      return;
-    }
-
-    // Collaborator count ceiling gating
-    const isPaid = hasPaidKylrixPlan(user) || currentTier === 'PRO' || currentTier === 'TEAMS' || currentTier === 'ORG' || currentTier === 'LIFETIME';
-    if (!isPaid && collaboratorProfiles.length + selectedUsers.length >= 3) {
-      toast.error(`Limit reached: Free plans are limited to 3 collaborators per resource. Upgrade to PRO to add more!`);
-      openProUpgrade(resourceType === 'project' ? 'Projects' : 'Collaborators');
-      return;
-    }
 
     setLoading(true);
     let successCount = 0;

--- a/components/settings/WorkspaceTab.tsx
+++ b/components/settings/WorkspaceTab.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { 
   FolderKanban, 
-  Users, 
   UserPlus, 
   UserMinus, 
   Globe, 
@@ -433,14 +432,26 @@ export function WorkspaceTab({ onGoToDevelopers }: { onGoToDevelopers?: () => vo
 
       {/* Members & Collaborators */}
       <div className="p-6 md:p-8 rounded-[24px] bg-[#161412] border-2 border-white/20 shadow-xl space-y-5">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-base md:text-lg font-black text-white font-clash m-0">Members & Collaborators</h2>
-            <p className="text-xs text-white/40 mt-0.5 m-0">Manage people with access to this workspace</p>
+            <p className="text-xs text-white/40 mt-0.5 m-0">View, invite, and manage collaborators with access to this workspace</p>
           </div>
-          <div className="w-8 h-8 rounded-xl bg-[#0A0908] border-2 border-white/15 grid place-items-center text-[#818CF8]">
-            <Users size={15} />
-          </div>
+          <button
+            type="button"
+            onClick={() => {
+              openDrawer('share-note', {
+                resourceType: 'project',
+                resourceId: activeWorkspace.id,
+                resourceTitle: activeWorkspace.title,
+                onShared: () => { void loadWorkspaceDetails(); },
+              });
+            }}
+            className="inline-flex items-center gap-1.5 h-9 px-3.5 rounded-xl bg-[#6366F1] hover:bg-[#5254E8] text-white text-xs font-bold transition-all cursor-pointer border-2 border-[#6366F1] shadow-md"
+          >
+            <UserPlus size={13} />
+            <span>Manage & Invite</span>
+          </button>
         </div>
 
         <form onSubmit={handleAddMember} className="flex gap-2.5">
@@ -478,18 +489,42 @@ export function WorkspaceTab({ onGoToDevelopers }: { onGoToDevelopers?: () => vo
                   </div>
                   <div className="min-w-0">
                     <div className="text-xs font-bold text-white font-mono truncate">{c.userId || c.entityId}</div>
-                    <div className="text-[10px] text-white/40 uppercase font-mono font-bold">{c.role || 'Member'}</div>
+                    <div className="text-[10px] text-white/40 uppercase font-mono font-bold">{c.role || c.permission || 'Member'}</div>
                   </div>
                 </div>
 
-                <button
-                  type="button"
-                  onClick={() => handleRemoveMember(c.userId || c.entityId)}
-                  className="p-1.5 text-white/40 hover:text-red-400 hover:bg-white/5 rounded-lg transition-colors cursor-pointer"
-                  title="Remove Member"
-                >
-                  <UserMinus size={14} />
-                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      openDrawer('share-note', {
+                        resourceType: 'project',
+                        resourceId: activeWorkspace.id,
+                        resourceTitle: activeWorkspace.title,
+                        initialCollaborator: {
+                          userId: c.userId || c.entityId,
+                          username: c.username || c.userId || c.entityId,
+                          displayName: c.displayName || c.userId || c.entityId,
+                          avatar: c.avatar || null,
+                          permissionLevel: c.permission === 'admin' ? 'admin' : (c.permission === 'write' ? 'editor' : 'viewer'),
+                        },
+                        onShared: () => { void loadWorkspaceDetails(); },
+                      });
+                    }}
+                    className="p-1.5 text-xs text-[#818CF8] hover:text-white hover:bg-white/5 rounded-lg transition-colors cursor-pointer font-medium"
+                    title="Edit Access Level"
+                  >
+                    Edit Access
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveMember(c.userId || c.entityId)}
+                    className="p-1.5 text-white/40 hover:text-red-400 hover:bg-white/5 rounded-lg transition-colors cursor-pointer"
+                    title="Remove Member"
+                  >
+                    <UserMinus size={14} />
+                  </button>
+                </div>
               </div>
             ))
           )}

--- a/lib/actions/secure-ops/permissions.ts
+++ b/lib/actions/secure-ops/permissions.ts
@@ -5,11 +5,6 @@ import {
   ID, Query
 } from 'node-appwrite';
 import { APPWRITE_CONFIG } from '@/lib/appwrite/config';
-import { getUserSubscriptionTierServer } from '@/lib/services/internal/subscription-entitlement';
-import {
-  allowsCollaboratorSharing,
-  getCollaboratorCap
-} from '@/lib/entitlements';
 import { createSystemClient, createSystemTablesDB } from '@/lib/appwrite-admin';
 import { permissionsInternal } from '@/lib/services/internal/permissions';
 import { dispatchEmail } from '@/lib/services/internal/emailDispatch';
@@ -31,23 +26,6 @@ const {
   verifyProjectPermission,
   verifyFormPermission} = shared;
 
-async function resolveCollaboratorBillingUserId(
-  resourceType: string,
-  resourceId: string,
-  requesterId: string,
-): Promise<string> {
-  if (resourceType !== 'project') return requesterId;
-  try {
-    const tables = createSystemTablesDB();
-    const project = await tables.getRow({
-      databaseId: APPWRITE_CONFIG.DATABASES.CHAT,
-      tableId: 'projects',
-      rowId: resourceId}) as { ownerId?: string | null; userId?: string | null };
-    return String(project.ownerId || project.userId || requesterId).trim() || requesterId;
-  } catch {
-    return requesterId;
-  }
-}
 
 function membershipIsAccepted(membership: { confirm?: boolean; joined?: string | boolean }): boolean {
   if (membership.confirm === true) return true;
@@ -214,31 +192,7 @@ export async function grantPermissionSecure(input: PermissionChangeInput) {
         ])
       : Query.equal('resourceType', resourceType);
 
-    // Enforce 3-collaborator limit for FREE tier
-    const existingCollabsRes = await tables.listRows({
-      databaseId: FLOW_DATABASE_ID,
-      tableId: COLLABORATORS_TABLE,
-      queries: [
-        Query.equal('resourceId', input.resourceId),
-        collabTypeFilter,
-      ] as any
-    });
-
-    const billingUserId = await resolveCollaboratorBillingUserId(resourceType, input.resourceId, requester.$id);
-    const userTier = await getUserSubscriptionTierServer(billingUserId);
-    if (!allowsCollaboratorSharing(userTier, resourceType)) {
-      if (resourceType === 'project') {
-        throw new Error('Project collaboration is a TEAMS feature. Upgrade the project owner to TEAMS to collaborate on projects.');
-      }
-      throw new Error(`Adding collaborators is a premium feature. Upgrade to PRO or TEAMS to collaborate on your ${resourceType}.`);
-    }
-    const maxCollabs = getCollaboratorCap(userTier, resourceType);
-    if (existingCollabsRes.rows.length >= maxCollabs) {
-      if (resourceType === 'project') {
-        throw new Error('Project collaboration is limited to TEAMS plan. Upgrade to TEAMS for unlimited team members.');
-      }
-      throw new Error(`Limit reached. Upgrade to PRO or TEAMS for unlimited collaborators on your ${resourceType}.`);
-    }
+    // Note: Collaborators are free and limitless on all plans
 
     const existingCollab = await tables.listRows({
       databaseId: FLOW_DATABASE_ID,
@@ -643,30 +597,7 @@ export async function addProjectCollaboratorSecure(projectId: string, targetUser
       tableId: 'projects',
       rowId: projectId});
 
-  // Enforce 3-collaborator limit for FREE tier
-  const FLOW_DATABASE_ID = APPWRITE_CONFIG.DATABASES.FLOW;
-  const COLLABORATORS_TABLE = APPWRITE_CONFIG.TABLES.FLOW.COLLABORATORS || 'Collaborators';
-
-  const existingCollabsRes = await tables.listRows({
-    databaseId: FLOW_DATABASE_ID,
-    tableId: COLLABORATORS_TABLE,
-    queries: [
-      Query.equal('resourceId', projectId),
-      Query.equal('resourceType', 'project')
-    ] as any
-  });
-
-  const ownerTier = await getUserSubscriptionTierServer(project.ownerId);
-
-  if (!allowsCollaboratorSharing(ownerTier, 'project')) {
-    throw new Error('Project collaboration is a TEAMS feature. Upgrade the project owner to TEAMS to collaborate on projects.');
-  }
-
-  const maxCollabs = getCollaboratorCap(ownerTier, 'project');
-  if (existingCollabsRes.rows.length >= maxCollabs) {
-    throw new Error('Project collaboration is limited to TEAMS plan. Upgrade the project owner to TEAMS for unlimited team members.');
-  }
-
+  // Note: Collaborators are free and limitless on all plans
   const { teams } = createSystemClient();
   const teamRole = permissionLevel === 'admin'
     ? 'admin'

--- a/lib/api/permission-updater.ts
+++ b/lib/api/permission-updater.ts
@@ -1,7 +1,6 @@
 import { Databases, ID, Permission, Query, Role, Storage } from 'node-appwrite';
 import { createHash } from 'node:crypto';
 import { APPWRITE_CONFIG } from '@/lib/appwrite/config';
-import { hasPaidKylrixPlanServer } from '@/lib/services/internal/subscription-entitlement';
 import { createSystemClient } from '@/lib/appwrite-admin';
 
 function getResourceTypeFromTableId(tableId: string): string | null {
@@ -44,17 +43,7 @@ export async function provisionHybridTeamExpansionSecure(
       uniqueCollabIds.push(targetUserId);
   }
 
-  // If under limit, no team needed
-  if (uniqueCollabIds.length <= 3) {
-      return { isTeamExpanded: false, newAcl: null };
-  }
-
-  // 2. Enforce Pro limits
-  const isPro = await hasPaidKylrixPlanServer(ownerId);
-
-  if (!isPro) {
-      throw new Error('Limit reached: Free plan is limited to 3 collaborators. Upgrade to PRO for more team members.');
-  }
+  // Note: Collaborators are free and limitless on all plans
 
   const teamId = `rt_${resourceId.replace(/[^a-zA-Z0-9_]/g, '').slice(0, 30)}`;
 

--- a/lib/deployment/surface.ts
+++ b/lib/deployment/surface.ts
@@ -52,3 +52,16 @@ export function isBillingCommerceEnabled(): boolean {
   }
   return readPricingTiersClientEnv() && !readSelfHostedClientEnv();
 }
+
+/**
+ * KYLRIX_CLOUD mode: indicates official Kylrix Cloud ecosystem runtime.
+ * Allows applying custom hand-wired shortcuts and logic for Kylrix main cloud
+ * directly in code while bypassing pricing tier envs.
+ */
+export function isKylrixCloud(): boolean {
+  const flag =
+    typeof window === 'undefined'
+      ? process.env.KYLRIX_CLOUD || process.env.NEXT_PUBLIC_KYLRIX_CLOUD
+      : process.env.NEXT_PUBLIC_KYLRIX_CLOUD || (window as any)?.__KYLRIX_CLOUD__;
+  return parseEnvFlag(flag);
+}

--- a/lib/entitlements/policy.ts
+++ b/lib/entitlements/policy.ts
@@ -44,24 +44,14 @@ export function effectiveTierHasPaidAccess(tier?: BillingUiTier | string | null)
   return billingTierHasPaidAccess(tier || 'FREE');
 }
 
-export function allowsCollaboratorSharing(tier: BillingUiTier | string, resourceType?: string): boolean {
-  if (isSelfHostedDeployment()) {
-    return true;
-  }
-  if (resourceType === 'project') {
-    return ledgerMeetsFeature(tier, 'projects');
-  }
-  return ledgerMeetsFeature(tier, 'sharing');
+export function allowsCollaboratorSharing(_tier?: BillingUiTier | string, _resourceType?: string): boolean {
+  // Collaborators are free and limitless on all plans across selfhosted and cloud deployments
+  return true;
 }
 
-export function getCollaboratorCap(tier: BillingUiTier | string, resourceType?: string): number {
-  if (isSelfHostedDeployment()) {
-    return Number.POSITIVE_INFINITY;
-  }
-  if (resourceType === 'project') {
-    return ledgerMeetsFeature(tier, 'projects') ? Number.POSITIVE_INFINITY : 0;
-  }
-  return ledgerMeetsFeature(tier, 'sharing') ? Number.POSITIVE_INFINITY : 0;
+export function getCollaboratorCap(_tier?: BillingUiTier | string, _resourceType?: string): number {
+  // Collaborators are free and limitless on all plans across selfhosted and cloud deployments
+  return Number.POSITIVE_INFINITY;
 }
 
 export function getProjectCap(_tier: BillingUiTier | string): number {

--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,10 @@ const nextConfig = {
       (process.env.PRICING_TIERS_ENABLED ?? process.env.ENABLE_PRICING_TIERS) === 'true'
         ? 'true'
         : 'false',
+    NEXT_PUBLIC_KYLRIX_CLOUD:
+      (process.env.KYLRIX_CLOUD ?? process.env.NEXT_PUBLIC_KYLRIX_CLOUD) === 'true'
+        ? 'true'
+        : 'false',
     NEXT_PUBLIC_PRICING_PLANS_JSON: buildPublicPricingPlansJson(),
   },
   // Standalone output produces a self-contained server in .next/standalone


### PR DESCRIPTION
This change introduces the `KYLRIX_CLOUD` / `NEXT_PUBLIC_KYLRIX_CLOUD` environment flag and helper `isKylrixCloud()`, updates collaborator entitlement policies and backend/client checks to make collaborators free and unlimited on all plans, and enhances the Settings > Workspace UI to view and manage workspace collaborators via the unified share drawer.

---
*PR created automatically by Jules for task [838324782591787744](https://jules.google.com/task/838324782591787744) started by @nathfavour*