### PR TITLE
security: harden XSS defenses and cookie security flags

### DIFF
--- a/lib/appwrite/client.ts
+++ b/lib/appwrite/client.ts
@@ -627,7 +627,8 @@ export function setKylrixPulse(user: any, avatarBase64?: string | null) {
         };
         
         const domainStr = getCookieDomain();
-        document.cookie = `${PULSE_COOKIE_NAME}=${encodeURIComponent(JSON.stringify(pulse))}; path=/; ${domainStr}max-age=31536000; SameSite=Lax`;
+        const secureStr = window.location.protocol === 'https:' ? 'Secure; ' : '';
+        document.cookie = `${PULSE_COOKIE_NAME}=${encodeURIComponent(JSON.stringify(pulse))}; path=/; ${domainStr}${secureStr}max-age=31536000; SameSite=Lax`;
         if (avatarBase64) localStorage.setItem(AVATAR_CACHE_PREFIX + user.$id, avatarBase64);
         (window as any).__KYLRIX_PULSE__ = { ...pulse, avatarBase64: avatarBase64 || localStorage.getItem(AVATAR_CACHE_PREFIX + user.$id) };
     } catch (_e) {}
@@ -636,10 +637,11 @@ export function setKylrixPulse(user: any, avatarBase64?: string | null) {
 export function clearKylrixPulse() {
     if (typeof window === 'undefined') return;
     const domainStr = getCookieDomain();
+    const secureStr = window.location.protocol === 'https:' ? 'Secure; ' : '';
     if (domainStr) {
-        document.cookie = `${PULSE_COOKIE_NAME}=; path=/; ${domainStr}expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+        document.cookie = `${PULSE_COOKIE_NAME}=; path=/; ${domainStr}${secureStr}expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
     }
-    document.cookie = `${PULSE_COOKIE_NAME}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    document.cookie = `${PULSE_COOKIE_NAME}=; path=/; ${secureStr}expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
     delete (window as any).__KYLRIX_PULSE__;
     document.documentElement.removeAttribute('data-kylrix-pulse');
 }

--- a/lib/ecosystem/state-tracker.ts
+++ b/lib/ecosystem/state-tracker.ts
@@ -20,7 +20,8 @@ function mirrorLastRouteCookie(path: string) {
         ? ''
         : `.${APPWRITE_CONFIG.SYSTEM.DOMAIN}`;
     const domainStr = domain ? `domain=${domain}; ` : '';
-    document.cookie = `${LAST_ROUTE_COOKIE}=${encodeURIComponent(path)}; path=/; ${domainStr}max-age=2592000; SameSite=Lax`;
+    const secureStr = window.location.protocol === 'https:' ? 'Secure; ' : '';
+    document.cookie = `${LAST_ROUTE_COOKIE}=${encodeURIComponent(path)}; path=/; ${domainStr}${secureStr}max-age=2592000; SameSite=Lax`;
   } catch {
     // Best effort only.
   }

--- a/lib/markdown/render.test.ts
+++ b/lib/markdown/render.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdownHtml } from './render';
+
+describe('renderMarkdownHtml security & sanitization', () => {
+  it('strips inline script tags and dangerous execution payloads', () => {
+    const raw = '# Hello\n<script>alert("xss")</script>\nWorld';
+    const html = renderMarkdownHtml(raw);
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('alert');
+    expect(html).toContain('Hello');
+    expect(html).toContain('World');
+  });
+
+  it('removes inline event handler attributes like onerror and onload', () => {
+    const raw = '<img src="invalid.png" onerror="alert(1)" onload="alert(2)">';
+    const html = renderMarkdownHtml(raw);
+    expect(html).not.toContain('onerror');
+    expect(html).not.toContain('onload');
+    expect(html).not.toContain('alert');
+    expect(html).toContain('<img src="invalid.png">');
+  });
+
+  it('strips javascript: protocol pseudo-URLs in links', () => {
+    const raw = '[Click Me](javascript:alert(1))';
+    const html = renderMarkdownHtml(raw);
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('Click Me');
+  });
+
+  it('preserves valid markdown styling and standard safe elements', () => {
+    const raw = '**Bold** and *Italic* text with `inline code`';
+    const html = renderMarkdownHtml(raw);
+    expect(html).toContain('<strong>Bold</strong>');
+    expect(html).toContain('<em>Italic</em>');
+    expect(html).toContain('<code>inline code</code>');
+  });
+});

--- a/lib/markdown/render.ts
+++ b/lib/markdown/render.ts
@@ -2,6 +2,7 @@ import { isFlowInstalled } from '@/lib/flows/installed';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import type { Config as DomPurifyConfig } from 'dompurify';
+import { Window } from 'happy-dom';
 import { preProcessMarkdown } from '@/lib/markdown/preprocess';
 import {
   defaultMathModeContext,
@@ -11,6 +12,18 @@ import {
 import { registerMathTransforms } from '@/lib/markdown/math';
 
 let layersReady = false;
+let serverPurify: typeof DOMPurify | null = null;
+
+function sanitizeHtml(html: string): string {
+  if (typeof window !== 'undefined') {
+    return String(DOMPurify.sanitize(html, MATH_PURIFY));
+  }
+  if (!serverPurify) {
+    const win = new Window();
+    serverPurify = DOMPurify(win as unknown as Window & typeof globalThis);
+  }
+  return String(serverPurify.sanitize(html, MATH_PURIFY));
+}
 
 export function ensureMarkdownLayers() {
   if (layersReady) return;
@@ -103,8 +116,7 @@ export function renderMarkdownHtml(
   const pre = runMarkdownPipeline(prepped, 'pre', context);
   const raw = marked.parse(pre) as string;
   const post = runMarkdownPipeline(raw, 'post', context);
-  if (typeof window === 'undefined') return post;
-  return String(DOMPurify.sanitize(post, MATH_PURIFY));
+  return sanitizeHtml(post);
 }
 
 export function isMathModeFlowInstalled(): boolean {

--- a/lib/services/referral-client.ts
+++ b/lib/services/referral-client.ts
@@ -7,7 +7,8 @@ const COOKIE_NAME = 'attribution_payload';
 
 function clearAttributionCookie() {
   if (typeof document === 'undefined') return;
-  document.cookie = `${COOKIE_NAME}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
+  const secureStr = typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'Secure; ' : '';
+  document.cookie = `${COOKIE_NAME}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; ${secureStr}SameSite=Lax`;
 }
 
 function readAttributionPayload(): { ref: string; src?: string; origin?: string; timestamp?: number } | null {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -150,14 +150,15 @@ export function getEffectiveUsername(user: any): string | null {
 // Clear stale session cookies to prevent overlapping session identity bugs
 export function clearStatelessSessions() {
   try {
-    document.cookie = "kylrix_pulse_v2=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT;";
+    const secureStr = typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'Secure; ' : '';
+    document.cookie = `kylrix_pulse_v2=; path=/; ${secureStr}expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
     document.cookie.split(";").forEach((cookie) => {
       const eqPos = cookie.indexOf("=");
       const name = eqPos > -1 ? cookie.substring(0, eqPos).trim() : cookie.trim();
       if (name.startsWith("a_session_")) {
-        document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+        document.cookie = `${name}=; path=/; ${secureStr}expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
         const domain = window.location.hostname;
-        document.cookie = `${name}=; path=/; domain=${domain}; expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+        document.cookie = `${name}=; path=/; domain=${domain}; ${secureStr}expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
       }
     });
     // Keep sessionStorage partition pointers intact

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -1,4 +1,4 @@
-import { marked } from 'marked';
+import { renderMarkdownHtml } from '@/lib/markdown/render';
 
 /**
  * Downloads a text file dynamically on the client.
@@ -41,7 +41,7 @@ export function exportToPDF(title: string, markdownContent: string) {
 
   let parsedHtml = '';
   try {
-    parsedHtml = String(marked.parse(markdownContent));
+    parsedHtml = renderMarkdownHtml(markdownContent);
   } catch (_err) {
     parsedHtml = markdownContent.replace(/\n/g, '<br/>');
   }
@@ -95,7 +95,7 @@ export function exportToPDF(title: string, markdownContent: string) {
 export function exportToDOCX(title: string, markdownContent: string) {
   let parsedHtml = '';
   try {
-    parsedHtml = String(marked.parse(markdownContent));
+    parsedHtml = renderMarkdownHtml(markdownContent);
   } catch {
     parsedHtml = markdownContent.replace(/\n/g, '<br/>');
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -72,6 +72,8 @@ export function middleware(request: NextRequest) {
       maxAge: 60 * 60 * 24 * 30, // 30 days
       path: '/',
       sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      httpOnly: true,
     });
     return response;
   };
@@ -295,6 +297,7 @@ export function middleware(request: NextRequest) {
     maxAge: Math.ceil(RELOAD_WINDOW_MS / 1000),
     httpOnly: true,
     sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
   });
 
   return response;

--- a/next.config.js
+++ b/next.config.js
@@ -363,6 +363,31 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'SAMEORIGIN',
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+      {
         source: '/(idea|flow|flows|goal|goals|form|forms|vault|workspaces|app|settings|moment)/:path*',
         headers: [
           {


### PR DESCRIPTION
Harden application security against potential XSS and cookie vulnerabilities:
1. Universal DOMPurify sanitization across client and server (SSR/RSC) environments in `lib/markdown/render.ts`.
2. Markdown sanitization applied to document exports in `lib/utils/export.ts`.
3. Cookie flags hardened with `Secure`, `HttpOnly`, and `SameSite=Lax` across middleware and client cookie handlers.
4. Added global HTTP security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`) in `next.config.js`.
5. Unit tests added and verified in `lib/markdown/render.test.ts`.

---
*PR created automatically by Jules for task [11032745013248767143](https://jules.google.com/task/11032745013248767143) started by @nathfavour*